### PR TITLE
MT-23076: support expires_at on the api token tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1034,7 +1034,7 @@ Create a new API token. The response includes the secret `token` value — this 
 **Parameters:**
 
 - `name` (required): Display name for the token
-- `expires_at` (optional): Token expiration as an ISO 8601 date-time. Omit for the server default (a 1-year default is being rolled out); pass an explicit `null` for a token that never expires. Past values or values more than 5 years ahead are rejected
+- `expires_at` (optional): Token expiration as an ISO 8601 date-time. Omit for the server default (1 year); pass an explicit `null` for a token that never expires. Past values or values more than 5 years ahead are rejected
 - `resources` (optional): Array of resource permissions to scope the token to. Each entry has:
   - `resource_type` (required): One of `account`, `project`, `inbox`, `domain`, `billing`
   - `resource_id` (required): ID of the resource
@@ -1055,7 +1055,7 @@ Reset (rotate) an API token by ID. The response includes the **new** secret `tok
 **Parameters:**
 
 - `api_token_id` (required): ID of the API token to reset
-- `expires_at` (optional): Expiration for the new token as an ISO 8601 date-time. Omit for the server default (a 1-year default is being rolled out); pass an explicit `null` for a token that never expires. Past values or values more than 5 years ahead are rejected
+- `expires_at` (optional): Expiration for the new token as an ISO 8601 date-time. Omit for the server default (1 year); pass an explicit `null` for a token that never expires. Past values or values more than 5 years ahead are rejected
 
 ### delete-api-token
 

--- a/README.md
+++ b/README.md
@@ -916,6 +916,7 @@ Create a new API token. The response includes the secret `token` value — this 
 **Parameters:**
 
 - `name` (required): Display name for the token
+- `expires_at` (optional): Token expiration as an ISO 8601 date-time. Omit for the server default (a 1-year default is being rolled out); pass an explicit `null` for a token that never expires. Past values or values more than 5 years ahead are rejected
 - `resources` (optional): Array of resource permissions to scope the token to. Each entry has:
   - `resource_type` (required): One of `account`, `project`, `inbox`, `domain`, `billing`
   - `resource_id` (required): ID of the resource
@@ -936,6 +937,7 @@ Reset (rotate) an API token by ID. The response includes the **new** secret `tok
 **Parameters:**
 
 - `api_token_id` (required): ID of the API token to reset
+- `expires_at` (optional): Expiration for the new token as an ISO 8601 date-time. Omit for the server default (a 1-year default is being rolled out); pass an explicit `null` for a token that never expires. Past values or values more than 5 years ahead are rejected
 
 ### delete-api-token
 

--- a/README.md
+++ b/README.md
@@ -1034,6 +1034,7 @@ Create a new API token. The response includes the secret `token` value — this 
 **Parameters:**
 
 - `name` (required): Display name for the token
+- `expires_at` (optional): Token expiration as an ISO 8601 date-time. Omit for the server default (a 1-year default is being rolled out); pass an explicit `null` for a token that never expires. Past values or values more than 5 years ahead are rejected
 - `resources` (optional): Array of resource permissions to scope the token to. Each entry has:
   - `resource_type` (required): One of `account`, `project`, `inbox`, `domain`, `billing`
   - `resource_id` (required): ID of the resource
@@ -1054,6 +1055,7 @@ Reset (rotate) an API token by ID. The response includes the **new** secret `tok
 **Parameters:**
 
 - `api_token_id` (required): ID of the API token to reset
+- `expires_at` (optional): Expiration for the new token as an ISO 8601 date-time. Omit for the server default (a 1-year default is being rolled out); pass an explicit `null` for a token that never expires. Past values or values more than 5 years ahead are rejected
 
 ### delete-api-token
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "mcp-mailtrap",
-  "version": "0.8.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-mailtrap",
-      "version": "0.8.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.18.2",
         "dotenv": "^16.4.7",
         "mailsplit": "^5.4.6",
-        "mailtrap": "^4.9.0",
+        "mailtrap": "^4.10.0",
         "zod": "^3.24.2"
       },
       "bin": {
@@ -7689,9 +7689,9 @@
       }
     },
     "node_modules/mailtrap": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/mailtrap/-/mailtrap-4.9.0.tgz",
-      "integrity": "sha512-I21Q8DNt98xy5vExQVPWIoudp3DuhzsyPEvLKhp26lkLKoRlEUAwgswJcqSJtCD9MP1RC/E+gL9ER7UdJ4sE6g==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/mailtrap/-/mailtrap-4.10.0.tgz",
+      "integrity": "sha512-WgLKOmgy8HhvjXMb4S+E2NVjgJLbDUC17lMFKsKNwBxTBteD2sin2m2wuEVbdppluq5YL5A1saNhSW8FvUdm/g==",
       "license": "MIT",
       "dependencies": {
         "axios": ">=0.27",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-mailtrap",
-  "version": "0.8.0",
+  "version": "0.6.0",
   "mcpName": "io.mailtrap/mcp",
   "description": "Official MCP Server for Mailtrap",
   "license": "MIT",
@@ -39,7 +39,7 @@
     "@modelcontextprotocol/sdk": "^1.18.2",
     "dotenv": "^16.4.7",
     "mailsplit": "^5.4.6",
-    "mailtrap": "^4.9.0",
+    "mailtrap": "^4.10.0",
     "zod": "^3.24.2"
   },
   "overrides": {

--- a/src/server.ts
+++ b/src/server.ts
@@ -192,6 +192,7 @@ import {
   createApiTokenSchema,
   apiTokenSchema,
   getApiToken,
+  resetApiTokenSchema,
   resetApiToken,
   deleteApiToken,
 } from "./tools/apiTokens";
@@ -1032,7 +1033,7 @@ const tools = [
     name: "reset-api-token",
     description:
       "Reset (rotate) an API token by ID. The response includes the **new** secret `token` value — returned only on this call, so store it immediately. The previous token is invalidated.",
-    inputSchema: apiTokenSchema,
+    inputSchema: resetApiTokenSchema,
     handler: resetApiToken,
     annotations: {
       destructiveHint: true,

--- a/src/server.ts
+++ b/src/server.ts
@@ -219,6 +219,7 @@ import {
   createApiTokenSchema,
   apiTokenSchema,
   getApiToken,
+  resetApiTokenSchema,
   resetApiToken,
   deleteApiToken,
 } from "./tools/apiTokens";
@@ -1178,7 +1179,7 @@ const tools = [
     name: "reset-api-token",
     description:
       "Reset (rotate) an API token by ID. The response includes the **new** secret `token` value — returned only on this call, so store it immediately. The previous token is invalidated.",
-    inputSchema: apiTokenSchema,
+    inputSchema: resetApiTokenSchema,
     handler: resetApiToken,
     annotations: {
       destructiveHint: true,

--- a/src/tools/apiTokens/__tests__/createApiToken.test.ts
+++ b/src/tools/apiTokens/__tests__/createApiToken.test.ts
@@ -64,6 +64,40 @@ describe("createApiToken", () => {
     });
   });
 
+  it("forwards expires_at when provided", async () => {
+    mockClient.general.apiTokens.create.mockResolvedValue({
+      id: 9,
+      name: "Expiring",
+      expires_at: "2027-06-01T00:00:00Z",
+      token: "mt-token-expiring",
+    });
+
+    await createApiToken({
+      name: "Expiring",
+      expires_at: "2027-06-01T00:00:00Z",
+    });
+
+    expect(mockClient.general.apiTokens.create).toHaveBeenCalledWith({
+      name: "Expiring",
+      expires_at: "2027-06-01T00:00:00Z",
+    });
+  });
+
+  it("forwards an explicit null expires_at for a token that never expires", async () => {
+    mockClient.general.apiTokens.create.mockResolvedValue({
+      id: 10,
+      name: "Forever",
+      expires_at: null,
+      token: "mt-token-forever",
+    });
+
+    await createApiToken({ name: "Forever", expires_at: null });
+
+    const callArg = mockClient.general.apiTokens.create.mock.calls[0][0];
+    expect("expires_at" in callArg).toBe(true);
+    expect(callArg.expires_at).toBeNull();
+  });
+
   it("surfaces API errors", async () => {
     mockClient.general.apiTokens.create.mockRejectedValue(
       new Error("name taken")

--- a/src/tools/apiTokens/__tests__/resetApiToken.test.ts
+++ b/src/tools/apiTokens/__tests__/resetApiToken.test.ts
@@ -34,6 +34,55 @@ describe("resetApiToken", () => {
     expect(result.isError).toBeUndefined();
   });
 
+  it("forwards expires_at for the new token when provided", async () => {
+    mockClient.general.apiTokens.reset.mockResolvedValue({
+      id: 7,
+      name: "CI",
+      expires_at: "2027-06-01T00:00:00Z",
+      token: "mt-token-new",
+    });
+
+    await resetApiToken({
+      api_token_id: 7,
+      expires_at: "2027-06-01T00:00:00Z",
+    });
+
+    expect(mockClient.general.apiTokens.reset).toHaveBeenCalledWith(7, {
+      expires_at: "2027-06-01T00:00:00Z",
+    });
+  });
+
+  it("forwards an explicit null expires_at for a token that never expires", async () => {
+    mockClient.general.apiTokens.reset.mockResolvedValue({
+      id: 7,
+      name: "CI",
+      expires_at: null,
+      token: "mt-token-new",
+    });
+
+    await resetApiToken({ api_token_id: 7, expires_at: null });
+
+    expect(mockClient.general.apiTokens.reset).toHaveBeenCalledWith(7, {
+      expires_at: null,
+    });
+  });
+
+  it("surfaces server-side expiration validation errors", async () => {
+    mockClient.general.apiTokens.reset.mockRejectedValue(
+      new Error("expires_at: must not be in the past")
+    );
+
+    const result = await resetApiToken({
+      api_token_id: 7,
+      expires_at: "2020-01-01T00:00:00Z",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe(
+      "Failed to reset API token: expires_at: must not be in the past"
+    );
+  });
+
   it("surfaces API errors", async () => {
     mockClient.general.apiTokens.reset.mockRejectedValue(
       new Error("not found")

--- a/src/tools/apiTokens/index.ts
+++ b/src/tools/apiTokens/index.ts
@@ -4,6 +4,7 @@ import createApiTokenSchema from "./schemas/createApiToken";
 import createApiToken from "./createApiToken";
 import apiTokenSchema from "./schemas/apiToken";
 import getApiToken from "./getApiToken";
+import resetApiTokenSchema from "./schemas/resetApiToken";
 import resetApiToken from "./resetApiToken";
 import deleteApiToken from "./deleteApiToken";
 
@@ -14,6 +15,7 @@ export {
   createApiToken,
   apiTokenSchema,
   getApiToken,
+  resetApiTokenSchema,
   resetApiToken,
   deleteApiToken,
 };

--- a/src/tools/apiTokens/resetApiToken.ts
+++ b/src/tools/apiTokens/resetApiToken.ts
@@ -12,22 +12,12 @@ async function resetApiToken(
   try {
     const mailtrap = requireClient("API tokens");
 
-    // mailtrap@4.8 typings don't know the optional reset body yet – widen the
-    // signature locally and drop this cast once the dependency is bumped to
-    // the release that ships MT-23076.
-    const apiTokens = mailtrap.general.apiTokens as unknown as {
-      reset: (
-        id: number,
-        resetParams?: { expires_at?: string | null }
-      ) => Promise<unknown>;
-    };
-
     const response =
       "expires_at" in params
-        ? await apiTokens.reset(params.api_token_id, {
+        ? await mailtrap.general.apiTokens.reset(params.api_token_id, {
             expires_at: params.expires_at,
           })
-        : await apiTokens.reset(params.api_token_id);
+        : await mailtrap.general.apiTokens.reset(params.api_token_id);
 
     return buildSuccessResponse(JSON.stringify(response, null, 2));
   } catch (error) {

--- a/src/tools/apiTokens/resetApiToken.ts
+++ b/src/tools/apiTokens/resetApiToken.ts
@@ -1,18 +1,33 @@
 import { requireClient } from "../../client";
-import { ApiTokenRequest } from "../../types/mailtrap";
+import { ResetApiTokenRequest } from "../../types/mailtrap";
 import {
   buildErrorResponse,
   buildSuccessResponse,
   ToolResponse,
 } from "../utils/responses";
 
-async function resetApiToken({
-  api_token_id,
-}: ApiTokenRequest): Promise<ToolResponse> {
+async function resetApiToken(
+  params: ResetApiTokenRequest
+): Promise<ToolResponse> {
   try {
     const mailtrap = requireClient("API tokens");
 
-    const response = await mailtrap.general.apiTokens.reset(api_token_id);
+    // mailtrap@4.8 typings don't know the optional reset body yet – widen the
+    // signature locally and drop this cast once the dependency is bumped to
+    // the release that ships MT-23076.
+    const apiTokens = mailtrap.general.apiTokens as unknown as {
+      reset: (
+        id: number,
+        resetParams?: { expires_at?: string | null }
+      ) => Promise<unknown>;
+    };
+
+    const response =
+      "expires_at" in params
+        ? await apiTokens.reset(params.api_token_id, {
+            expires_at: params.expires_at,
+          })
+        : await apiTokens.reset(params.api_token_id);
 
     return buildSuccessResponse(JSON.stringify(response, null, 2));
   } catch (error) {

--- a/src/tools/apiTokens/schemas/createApiToken.ts
+++ b/src/tools/apiTokens/schemas/createApiToken.ts
@@ -8,7 +8,7 @@ const createApiTokenSchema = {
     expires_at: {
       type: ["string", "null"],
       description:
-        "Optional token expiration as an ISO 8601 date-time (e.g. 2027-06-01T00:00:00Z). Omit for the server default (a 1-year default is being rolled out). Pass an explicit null for a token that never expires. Past values or values more than 5 years ahead are rejected with a 422 error.",
+        "Optional token expiration as an ISO 8601 date-time (e.g. 2027-06-01T00:00:00Z). Omit for the server default (1 year). Pass an explicit null for a token that never expires. Past values or values more than 5 years ahead are rejected with a 422 error.",
     },
     resources: {
       type: "array",

--- a/src/tools/apiTokens/schemas/createApiToken.ts
+++ b/src/tools/apiTokens/schemas/createApiToken.ts
@@ -5,6 +5,11 @@ const createApiTokenSchema = {
       type: "string",
       description: "Display name for the API token.",
     },
+    expires_at: {
+      type: ["string", "null"],
+      description:
+        "Optional token expiration as an ISO 8601 date-time (e.g. 2027-06-01T00:00:00Z). Omit for the server default (a 1-year default is being rolled out). Pass an explicit null for a token that never expires. Past values or values more than 5 years ahead are rejected with a 422 error.",
+    },
     resources: {
       type: "array",
       description:

--- a/src/tools/apiTokens/schemas/resetApiToken.ts
+++ b/src/tools/apiTokens/schemas/resetApiToken.ts
@@ -1,0 +1,23 @@
+/**
+ * Input schema for reset-api-token: `api_token_id` plus an optional
+ * `expires_at` for the replacement token. Kept separate from the shared
+ * `apiTokenSchema` (get, delete), which allows no extra properties.
+ */
+const resetApiTokenSchema = {
+  type: "object",
+  properties: {
+    api_token_id: {
+      type: "number",
+      description: "ID of the API token.",
+    },
+    expires_at: {
+      type: ["string", "null"],
+      description:
+        "Optional expiration for the new token as an ISO 8601 date-time (e.g. 2027-06-01T00:00:00Z). Omit for the server default (a 1-year default is being rolled out). Pass an explicit null for a token that never expires. Past values or values more than 5 years ahead are rejected with a 422 error.",
+    },
+  },
+  required: ["api_token_id"],
+  additionalProperties: false,
+};
+
+export default resetApiTokenSchema;

--- a/src/tools/apiTokens/schemas/resetApiToken.ts
+++ b/src/tools/apiTokens/schemas/resetApiToken.ts
@@ -13,7 +13,7 @@ const resetApiTokenSchema = {
     expires_at: {
       type: ["string", "null"],
       description:
-        "Optional expiration for the new token as an ISO 8601 date-time (e.g. 2027-06-01T00:00:00Z). Omit for the server default (a 1-year default is being rolled out). Pass an explicit null for a token that never expires. Past values or values more than 5 years ahead are rejected with a 422 error.",
+        "Optional expiration for the new token as an ISO 8601 date-time (e.g. 2027-06-01T00:00:00Z). Omit for the server default (1 year). Pass an explicit null for a token that never expires. Past values or values more than 5 years ahead are rejected with a 422 error.",
     },
   },
   required: ["api_token_id"],

--- a/src/tools/permissions/__tests__/bulkUpdatePermissions.test.ts
+++ b/src/tools/permissions/__tests__/bulkUpdatePermissions.test.ts
@@ -41,7 +41,7 @@ describe("bulkUpdatePermissions", () => {
       mockClient.general.permissions.bulkPermissionsUpdate
     ).toHaveBeenCalledWith(42, [
       { resourceId: "100", resourceType: "project", accessLevel: "100" },
-      { resourceId: "uuid-1", resourceType: "domain", destroy: "true" },
+      { resourceId: "uuid-1", resourceType: "domain", destroy: true },
     ]);
     expect(result.content[0].text).toContain('"access_level": 100');
     expect(result.isError).toBeUndefined();

--- a/src/tools/permissions/bulkUpdatePermissions.ts
+++ b/src/tools/permissions/bulkUpdatePermissions.ts
@@ -19,7 +19,7 @@ async function bulkUpdatePermissions({
       ...(p.access_level !== undefined && {
         accessLevel: String(p.access_level),
       }),
-      ...(p.destroy !== undefined && { destroy: String(p.destroy) }),
+      ...(p.destroy !== undefined && { destroy: p.destroy }),
     }));
 
     const response = await mailtrap.general.permissions.bulkPermissionsUpdate(

--- a/src/types/mailtrap.ts
+++ b/src/types/mailtrap.ts
@@ -667,6 +667,7 @@ export interface ApiTokenResourcePermission {
 
 export interface CreateApiTokenRequest {
   name: string;
+  expires_at?: string | null;
   resources?: ApiTokenResourcePermission[];
 }
 

--- a/src/types/mailtrap.ts
+++ b/src/types/mailtrap.ts
@@ -863,6 +863,11 @@ export interface ApiTokenRequest {
   api_token_id: number;
 }
 
+export interface ResetApiTokenRequest {
+  api_token_id: number;
+  expires_at?: string | null;
+}
+
 // --- Organization / sub-account types ---
 
 export interface SubAccount {

--- a/src/types/mailtrap.ts
+++ b/src/types/mailtrap.ts
@@ -675,6 +675,11 @@ export interface ApiTokenRequest {
   api_token_id: number;
 }
 
+export interface ResetApiTokenRequest {
+  api_token_id: number;
+  expires_at?: string | null;
+}
+
 // --- Organization / sub-account types ---
 
 export interface SubAccount {

--- a/src/types/mailtrap.ts
+++ b/src/types/mailtrap.ts
@@ -855,6 +855,7 @@ export interface ApiTokenResourcePermission {
 
 export interface CreateApiTokenRequest {
   name: string;
+  expires_at?: string | null;
   resources?: ApiTokenResourcePermission[];
 }
 


### PR DESCRIPTION
## Motivation

MT-23076

The API token endpoints now accept an optional `expires_at` (`createApiToken` request body and a new optional `resetApiToken` body). This exposes it on the `create-api-token` and `reset-api-token` tools.

## Changes

- add `expires_at` (`type: ["string", "null"]`) to the `create-api-token` input schema and `CreateApiTokenRequest`; the description spells out the tri-state for the LLM (omit = server default, null = never expires, 5-year cap)
- new dedicated `resetApiToken` input schema – reset previously shared `apiTokenSchema` with get/delete, which has `additionalProperties: false` and would reject the new parameter; get/delete keep the shared schema
- `reset-api-token` handler forwards `{ expires_at }` to `apiTokens.reset(id, body)` only when the key is present, so calls without it keep sending no request body
- document both parameters in the README tool reference

## How to test

- [ ] `create-api-token` with only a name – token created, expiration behavior unchanged (server default applies once rolled out)
- [ ] `create-api-token` with `expires_at: "2027-06-01T00:00:00Z"` – created token reports that expiration
- [ ] `create-api-token` with `expires_at: null` – created token never expires
- [ ] `create-api-token` with a past `expires_at` – tool returns the server's 422 validation error
- [ ] `reset-api-token` with only `api_token_id` – works exactly as before (no request body sent)
- [ ] `reset-api-token` with `expires_at: null` – new token never expires

## Companion PRs

- falcon – railsware/falcon#10763
- spec – mailtrap/mailtrap-openapi#51
- nodejs – mailtrap/mailtrap-nodejs#149
- php – mailtrap/mailtrap-php#75
- python – mailtrap/mailtrap-python#77
- ruby – mailtrap/mailtrap-ruby#122
- java – mailtrap/mailtrap-java#68
- dotnet – mailtrap/mailtrap-dotnet#253
- go – mailtrap/mailtrap-go#28
- cli – mailtrap/mailtrap-cli#12

`mailtrap` is bumped to `^4.10.0`, which ships the typed `reset(id, params?)` from the mailtrap-nodejs companion PR; the local signature cast in `src/tools/apiTokens/resetApiToken.ts` is gone.

Caveat: release/merge only after falcon deploys MT-23076 and zap_api_token_expiration is enabled in production.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API tokens can include an optional expiration date when created or reset.
  * Set `expires_at` to `null` for tokens that never expire.
  * Expiration dates use ISO 8601 format and supported validation limits.
* **Bug Fixes**
  * Reset-token requests apply the correct validation rules and surface expiration errors.
  * Permission updates now correctly process the deletion flag.
* **Documentation**
  * Added guidance on default expiration behavior, non-expiring tokens, date format, and validation limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
