### PR TITLE
Add sending domain settings, company info, create suppression and tracking opt-outs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,7 @@ Folders contain inboxes; inboxes receive messages, grouped into threads.
 #### Suppressions
 
 - **list-suppressions**: List or search suppressions; optional `email` filter. Up to 1000 results per call.
+- **create-suppression**: Add an email address to the suppression list.
 - **delete-suppression**: Delete a suppression by ID.
 
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,7 @@ Folders contain inboxes; inboxes receive messages, grouped into threads.
 - **list-sending-domains**: List sending domains and their DNS verification status.
 - **get-sending-domain**: Get a sending domain by ID and its verification status. With `include_setup_instructions: true`, append DNS setup instructions to the response.
 - **create-sending-domain**: Create a new sending domain.
+- **update-sending-domain**: Update a domain's tracking and inbound settings.
 - **delete-sending-domain**: Delete a sending domain.
 - **send-sending-domain-setup-instructions**: Email DNS setup instructions for a sending domain to a given address.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ Schema files define a JSON Schema–shaped object for MCP; optional Zod schemas 
 ### Environment Variables Required
 
 - `MAILTRAP_API_TOKEN`: Required API token from Mailtrap
-- `MAILTRAP_ACCOUNT_ID`: Required by account-scoped tools — templates, stats, email logs, sandbox list/show, sending domains, suppressions. Not needed by send-email, send-sandbox-email, the email campaign tools or the company info tools, which resolve the account from the API token.
+- `MAILTRAP_ACCOUNT_ID`: Required by account-scoped tools — templates, stats, email logs, sandbox list/show, sending domains, suppressions. Not needed by send-email, send-sandbox-email, the email campaign tools, the company info tools or the tracking opt-out tools, which resolve the account from the API token.
 - `DEFAULT_FROM_EMAIL`: Optional. Default sender email when the tool does not receive a `from` parameter (send-email, send-sandbox-email).
 - `MAILTRAP_TEST_INBOX_ID`: Optional. Default test inbox ID for sandbox tools when the tool does not receive a `test_inbox_id` parameter. Enables switching inboxes per call via parameters.
 
@@ -143,6 +143,11 @@ Folders contain inboxes; inboxes receive messages, grouped into threads.
 - **list-suppressions**: List or search suppressions; optional `email` filter. Up to 1000 results per call.
 - **create-suppression**: Add an email address to the suppression list.
 - **delete-suppression**: Delete a suppression by ID.
+
+
+#### Tracking Opt-outs
+
+- **list-tracking-opt-outs**: List addresses excluded from open and click tracking.
 
 
 #### Webhooks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,7 @@ Folders contain inboxes; inboxes receive messages, grouped into threads.
 #### Company Info
 
 - **get-company-info**: Get the company info of a sending domain.
+- **create-company-info**: Set the company info of a sending domain.
 
 
 #### Suppressions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,7 @@ Folders contain inboxes; inboxes receive messages, grouped into threads.
 
 - **list-tracking-opt-outs**: List addresses excluded from open and click tracking.
 - **create-tracking-opt-out**: Exclude an address from tracking for a sending domain.
+- **delete-tracking-opt-out**: Remove an address from the opt-out list, so tracking applies again.
 
 
 #### Webhooks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ Schema files define a JSON Schema–shaped object for MCP; optional Zod schemas 
 ### Environment Variables Required
 
 - `MAILTRAP_API_TOKEN`: Required API token from Mailtrap
-- `MAILTRAP_ACCOUNT_ID`: Required for templates, stats, email logs, sandbox list/show, and sending domains. Optional only for send-email, send-sandbox-email, and the email campaign tools.
+- `MAILTRAP_ACCOUNT_ID`: Required by account-scoped tools — templates, stats, email logs, sandbox list/show, sending domains, suppressions. Not needed by send-email, send-sandbox-email, the email campaign tools or the company info tools, which resolve the account from the API token.
 - `DEFAULT_FROM_EMAIL`: Optional. Default sender email when the tool does not receive a `from` parameter (send-email, send-sandbox-email).
 - `MAILTRAP_TEST_INBOX_ID`: Optional. Default test inbox ID for sandbox tools when the tool does not receive a `test_inbox_id` parameter. Enables switching inboxes per call via parameters.
 
@@ -129,6 +129,11 @@ Folders contain inboxes; inboxes receive messages, grouped into threads.
 - **update-sending-domain**: Update a domain's tracking and inbound settings.
 - **delete-sending-domain**: Delete a sending domain.
 - **send-sending-domain-setup-instructions**: Email DNS setup instructions for a sending domain to a given address.
+
+
+#### Company Info
+
+- **get-company-info**: Get the company info of a sending domain.
 
 
 #### Suppressions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,7 @@ Folders contain inboxes; inboxes receive messages, grouped into threads.
 
 - **get-company-info**: Get the company info of a sending domain.
 - **create-company-info**: Set the company info of a sending domain.
+- **update-company-info**: Update the company info of a sending domain.
 
 
 #### Suppressions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,7 @@ Folders contain inboxes; inboxes receive messages, grouped into threads.
 #### Tracking Opt-outs
 
 - **list-tracking-opt-outs**: List addresses excluded from open and click tracking.
+- **create-tracking-opt-out**: Exclude an address from tracking for a sending domain.
 
 
 #### Webhooks

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Once configured, you can ask agent to send emails and manage templates, for exam
 - "Delete sending domain 3938"
 - "Get sending domain 3938 with DNS setup instructions"
 - "Show the company info for sending domain 3938"
+- "Set the company info for domain 3938 to Acme Inc, 123 Main St, San Francisco, US, 94105, https://acme.com"
 
 ## Available Tools
 
@@ -637,6 +638,24 @@ Get the company info of a sending domain, used for domain compliance verificatio
 **Parameters:**
 
 - `sending_domain_id` (required): Sending domain ID
+
+### create-company-info
+
+Set the company info of a sending domain, required for domain compliance verification.
+
+**Parameters:**
+
+- `sending_domain_id` (required): Sending domain ID
+- `name` (required): Company or individual name
+- `address` (required): Street address
+- `city` (required): City
+- `country` (required): Country
+- `zip_code` (required): ZIP or postal code
+- `website_url` (required): Company website URL
+- `phone` (optional): Phone number
+- `privacy_policy_url` (optional): URL of the privacy policy page
+- `terms_of_service_url` (optional): URL of the terms of service page
+- `info_level` (optional): `business` or `individual`
 
 ### list-suppressions
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Before using this MCP server, you need to:
 **Required Environment Variables:**
 
 - `MAILTRAP_API_TOKEN` - Required for all functionality
-- `MAILTRAP_ACCOUNT_ID` - Required for templates, stats, email logs, sandbox list/show, sending domains, and suppressions. Optional only for the send tools (send-email, send-sandbox-email, and the batch-send-\* tools), the email campaign tools, and the company info tools.
+- `MAILTRAP_ACCOUNT_ID` - Required for templates, stats, email logs, sandbox list/show, sending domains, and suppressions. Optional only for the send tools (send-email, send-sandbox-email, and the batch-send-\* tools), the email campaign tools, the company info tools, and the tracking opt-out tools.
 
 **Optional (can be passed as tool parameters instead):**
 
@@ -206,6 +206,10 @@ Once configured, you can ask agent to send emails and manage templates, for exam
 
 - "List suppressions for bounced@example.com"
 - "Suppress bounced@example.com on the transactional stream of domain 3938"
+
+**Tracking Opt-outs:**
+
+- "List everyone who opted out of tracking"
 
 ## Available Tools
 
@@ -698,6 +702,17 @@ Delete a suppression by ID. Mailtrap will resume delivery to this email unless i
 **Parameters:**
 
 - `suppression_id` (required): ID of the suppression to delete
+
+### list-tracking-opt-outs
+
+List email addresses excluded from open and click tracking. Returns up to 1000 records per call.
+
+**Parameters:**
+
+- `email` (optional): Email filter. Returns only opt-outs matching this address
+- `start_time` (optional): Only opt-outs created at or after this time (ISO 8601)
+- `end_time` (optional): Only opt-outs created at or before this time (ISO 8601)
+- `last_id` (optional): Pagination cursor — the `last_id` from the previous response
 
 ### list-webhooks
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Once configured, you can ask agent to send emails and manage templates, for exam
 - "List my sending domains"
 - "Get sending domain with ID 3938"
 - "Create a sending domain for example.com"
+- "Turn on click tracking for sending domain 3938"
 - "Delete sending domain 3938"
 - "Get sending domain 3938 with DNS setup instructions"
 
@@ -595,6 +596,21 @@ Create a new sending domain. After creation, add DNS records to verify the domai
 **Parameters:**
 
 - `domain_name` (required): Domain name (e.g. example.com)
+
+### update-sending-domain
+
+Update a sending domain's tracking and inbound settings.
+
+**Parameters:**
+
+- `sending_domain_id` (required): Sending domain ID
+- `open_tracking_enabled` (optional): Track opens on emails sent from this domain
+- `click_tracking_enabled` (optional): Track clicks on links in emails sent from this domain
+- `tracking_opt_out_enabled` (optional): Add the tracking opt-out link to tracked emails. Requires open or click tracking
+- `auto_unsubscribe_link_enabled` (optional): Automatically add an unsubscribe link to emails
+- `inbound_enabled` (optional): Allow the domain to be attached to an inbound inbox as a catch-all
+
+At least one setting besides `sending_domain_id` must be provided.
 
 ### delete-sending-domain
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Before using this MCP server, you need to:
 **Required Environment Variables:**
 
 - `MAILTRAP_API_TOKEN` - Required for all functionality
-- `MAILTRAP_ACCOUNT_ID` - Required for templates, stats, email logs, sandbox list/show, and sending domains. Optional only for the send tools (send-email, send-sandbox-email, and the batch-send-\* tools) and the email campaign tools.
+- `MAILTRAP_ACCOUNT_ID` - Required for templates, stats, email logs, sandbox list/show, sending domains, and suppressions. Optional only for the send tools (send-email, send-sandbox-email, and the batch-send-\* tools), the email campaign tools, and the company info tools.
 
 **Optional (can be passed as tool parameters instead):**
 
@@ -198,6 +198,7 @@ Once configured, you can ask agent to send emails and manage templates, for exam
 - "Turn on click tracking for sending domain 3938"
 - "Delete sending domain 3938"
 - "Get sending domain 3938 with DNS setup instructions"
+- "Show the company info for sending domain 3938"
 
 ## Available Tools
 
@@ -628,6 +629,14 @@ Email DNS setup instructions for a sending domain to a given address. Useful for
 
 - `sending_domain_id` (required): Sending domain ID
 - `email` (required): Email address to send DNS setup instructions to
+
+### get-company-info
+
+Get the company info of a sending domain, used for domain compliance verification.
+
+**Parameters:**
+
+- `sending_domain_id` (required): Sending domain ID
 
 ### list-suppressions
 

--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ Once configured, you can ask agent to send emails and manage templates, for exam
 
 **Tracking Opt-outs:**
 
+- "Stop tracking opens and clicks for privacy@example.com on domain 3938"
 - "List everyone who opted out of tracking"
 
 ## Available Tools
@@ -713,6 +714,15 @@ List email addresses excluded from open and click tracking. Returns up to 1000 r
 - `start_time` (optional): Only opt-outs created at or after this time (ISO 8601)
 - `end_time` (optional): Only opt-outs created at or before this time (ISO 8601)
 - `last_id` (optional): Pagination cursor — the `last_id` from the previous response
+
+### create-tracking-opt-out
+
+Exclude an email address from open and click tracking for a sending domain.
+
+**Parameters:**
+
+- `email` (required): Email address to opt out of tracking
+- `domain_id` (required): ID of the sending domain the opt-out applies to
 
 ### list-webhooks
 

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Once configured, you can ask agent to send emails and manage templates, for exam
 - "Get sending domain 3938 with DNS setup instructions"
 - "Show the company info for sending domain 3938"
 - "Set the company info for domain 3938 to Acme Inc, 123 Main St, San Francisco, US, 94105, https://acme.com"
+- "Change the company info city for domain 3938 to New York"
 
 ## Available Tools
 
@@ -656,6 +657,15 @@ Set the company info of a sending domain, required for domain compliance verific
 - `privacy_policy_url` (optional): URL of the privacy policy page
 - `terms_of_service_url` (optional): URL of the terms of service page
 - `info_level` (optional): `business` or `individual`
+
+### update-company-info
+
+Update the company info of a sending domain.
+
+**Parameters:**
+
+- `sending_domain_id` (required): Sending domain ID
+- Every field of create-company-info, all optional. At least one must be provided; fields left out are unchanged.
 
 ### list-suppressions
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,11 @@ Once configured, you can ask agent to send emails and manage templates, for exam
 - "Set the company info for domain 3938 to Acme Inc, 123 Main St, San Francisco, US, 94105, https://acme.com"
 - "Change the company info city for domain 3938 to New York"
 
+**Suppressions:**
+
+- "List suppressions for bounced@example.com"
+- "Suppress bounced@example.com on the transactional stream of domain 3938"
+
 ## Available Tools
 
 ### send-email
@@ -674,6 +679,17 @@ List or search suppressions (hard bounces, spam complaints, unsubscriptions, man
 **Parameters:**
 
 - `email` (optional): Email filter. Returns only suppressions matching this address.
+
+### create-suppression
+
+Add an email address to the account's suppression list, so Mailtrap stops delivering to it.
+
+**Parameters:**
+
+- `email` (required): Email address to suppress
+- `domain_id` (required): ID of the sending domain the suppression applies to
+- `sending_stream` (required): `transactional` or `bulk`
+- `type` (optional): `hard bounce`, `spam complaint`, `unsubscription` or `manual import`. Defaults to `manual import`
 
 ### delete-suppression
 

--- a/README.md
+++ b/README.md
@@ -724,6 +724,14 @@ Exclude an email address from open and click tracking for a sending domain.
 - `email` (required): Email address to opt out of tracking
 - `domain_id` (required): ID of the sending domain the opt-out applies to
 
+### delete-tracking-opt-out
+
+Remove an email address from the tracking opt-out list, so open and click tracking applies to it again.
+
+**Parameters:**
+
+- `tracking_opt_out_id` (required): ID of the tracking opt-out to delete
+
 ### list-webhooks
 
 List all webhooks configured for the account. Returns the full webhook records as JSON.

--- a/manifest.json
+++ b/manifest.json
@@ -39,12 +39,24 @@
       "description": "Send emails via Mailtrap's delivery API with support for HTML/text content and multiple recipients."
     },
     {
+      "name": "batch-send-transactional-email",
+      "description": "Send a batch of transactional emails in one call, with shared fields and per-recipient overrides."
+    },
+    {
+      "name": "batch-send-bulk-email",
+      "description": "Send a batch of bulk emails in one call, with shared fields and per-recipient overrides."
+    },
+    {
       "name": "create-template",
       "description": "Create a new email template in Mailtrap."
     },
     {
       "name": "list-templates",
       "description": "List all email templates in your Mailtrap account."
+    },
+    {
+      "name": "get-template",
+      "description": "Get a single email template, including its subject, category, and HTML and text bodies."
     },
     {
       "name": "update-template",
@@ -57,6 +69,10 @@
     {
       "name": "send-sandbox-email",
       "description": "Send test emails to Mailtrap's sandbox environment without delivering to real recipients."
+    },
+    {
+      "name": "batch-send-sandbox-email",
+      "description": "Send a batch of emails in sandbox mode to a test inbox in one call."
     },
     {
       "name": "get-sandbox-messages",
@@ -73,6 +89,14 @@
     {
       "name": "create-sandbox-project",
       "description": "Create a new sandbox project to group test inboxes."
+    },
+    {
+      "name": "get-sandbox-project",
+      "description": "Get a sandbox project and the inboxes it contains."
+    },
+    {
+      "name": "update-sandbox-project",
+      "description": "Rename a sandbox project."
     },
     {
       "name": "delete-sandbox-project",
@@ -97,6 +121,78 @@
     {
       "name": "clean-sandbox-inbox",
       "description": "Delete all messages from a sandbox inbox without deleting the inbox itself."
+    },
+    {
+      "name": "list-sandboxes",
+      "description": "List all sandbox inboxes accessible to the API token, across every project."
+    },
+    {
+      "name": "mark-sandbox-as-read",
+      "description": "Mark all messages in a sandbox inbox as read."
+    },
+    {
+      "name": "reset-sandbox-credentials",
+      "description": "Reset the SMTP credentials of a sandbox inbox."
+    },
+    {
+      "name": "enable-sandbox-email-address",
+      "description": "Enable the forwarding email address of a sandbox inbox."
+    },
+    {
+      "name": "reset-sandbox-email-address",
+      "description": "Reset the forwarding email address of a sandbox inbox."
+    },
+    {
+      "name": "forward-sandbox-message",
+      "description": "Forward a sandbox message to a real email address."
+    },
+    {
+      "name": "update-sandbox-message",
+      "description": "Mark a single sandbox message as read or unread."
+    },
+    {
+      "name": "delete-sandbox-message",
+      "description": "Delete a single message from a sandbox inbox."
+    },
+    {
+      "name": "get-sandbox-message-spam-score",
+      "description": "Get the spam report and SpamAssassin score for a sandbox message."
+    },
+    {
+      "name": "get-sandbox-message-html-analysis",
+      "description": "Check a sandbox message's HTML for email client compatibility issues."
+    },
+    {
+      "name": "get-sandbox-message-headers",
+      "description": "Get the headers of a sandbox message."
+    },
+    {
+      "name": "get-sandbox-message-html",
+      "description": "Get the rendered HTML body of a sandbox message."
+    },
+    {
+      "name": "get-sandbox-message-text",
+      "description": "Get the plain text body of a sandbox message."
+    },
+    {
+      "name": "get-sandbox-message-raw",
+      "description": "Get the raw source of a sandbox message."
+    },
+    {
+      "name": "get-sandbox-message-eml",
+      "description": "Download a sandbox message as an EML file."
+    },
+    {
+      "name": "get-sandbox-message-html-source",
+      "description": "Get the unrendered HTML source of a sandbox message."
+    },
+    {
+      "name": "list-sandbox-attachments",
+      "description": "List the attachments on a sandbox message."
+    },
+    {
+      "name": "get-sandbox-attachment",
+      "description": "Get the details and download URL of a single sandbox message attachment."
     },
     {
       "name": "get-sending-stats",
@@ -131,6 +227,10 @@
       "description": "Delete a sending domain."
     },
     {
+      "name": "send-sending-domain-setup-instructions",
+      "description": "Email a sending domain's DNS setup instructions to a colleague."
+    },
+    {
       "name": "get-company-info",
       "description": "Get the company info of a sending domain, used for domain compliance verification."
     },
@@ -143,8 +243,16 @@
       "description": "Update the company info of a sending domain."
     },
     {
+      "name": "list-suppressions",
+      "description": "List or search the suppressed email addresses on the account."
+    },
+    {
       "name": "create-suppression",
       "description": "Add an email address to the account's suppression list, so Mailtrap stops delivering to it."
+    },
+    {
+      "name": "delete-suppression",
+      "description": "Remove an email address from the suppression list, so Mailtrap resumes delivering to it."
     },
     {
       "name": "list-tracking-opt-outs",
@@ -157,6 +265,274 @@
     {
       "name": "delete-tracking-opt-out",
       "description": "Remove an email address from the tracking opt-out list, so open and click tracking applies to it again."
+    },
+    {
+      "name": "list-webhooks",
+      "description": "List all webhooks configured on the account."
+    },
+    {
+      "name": "get-webhook",
+      "description": "Get a single webhook and its configuration."
+    },
+    {
+      "name": "create-webhook",
+      "description": "Create a webhook for email sending, audit log, or inbound receiving events."
+    },
+    {
+      "name": "update-webhook",
+      "description": "Update a webhook's URL, active state, payload format, or subscribed events."
+    },
+    {
+      "name": "delete-webhook",
+      "description": "Permanently delete a webhook."
+    },
+    {
+      "name": "get-contact",
+      "description": "Get a contact by ID or email address, with list memberships and custom fields."
+    },
+    {
+      "name": "create-contact",
+      "description": "Create a contact and optionally subscribe it to contact lists."
+    },
+    {
+      "name": "update-contact",
+      "description": "Update a contact's fields and list memberships."
+    },
+    {
+      "name": "delete-contact",
+      "description": "Permanently delete a contact."
+    },
+    {
+      "name": "create-contact-event",
+      "description": "Record an event against a contact to trigger automations."
+    },
+    {
+      "name": "list-contact-lists",
+      "description": "List the contact lists on the account."
+    },
+    {
+      "name": "get-contact-list",
+      "description": "Get a single contact list."
+    },
+    {
+      "name": "create-contact-list",
+      "description": "Create a new contact list."
+    },
+    {
+      "name": "update-contact-list",
+      "description": "Rename an existing contact list."
+    },
+    {
+      "name": "delete-contact-list",
+      "description": "Permanently delete a contact list."
+    },
+    {
+      "name": "list-contact-fields",
+      "description": "List the custom contact field definitions on the account."
+    },
+    {
+      "name": "get-contact-field",
+      "description": "Get a single custom contact field definition."
+    },
+    {
+      "name": "create-contact-field",
+      "description": "Create a custom contact field for use as a template variable."
+    },
+    {
+      "name": "update-contact-field",
+      "description": "Update the name, merge tag, or data type of a custom contact field."
+    },
+    {
+      "name": "delete-contact-field",
+      "description": "Permanently delete a custom contact field."
+    },
+    {
+      "name": "create-contact-import",
+      "description": "Bulk import contacts and return an import job to poll."
+    },
+    {
+      "name": "get-contact-import",
+      "description": "Get the status and counts of a contact import job."
+    },
+    {
+      "name": "create-contact-export",
+      "description": "Export the contacts matching a set of filters and return an export job to poll."
+    },
+    {
+      "name": "get-contact-export",
+      "description": "Get the status of a contact export job and its download link once finished."
+    },
+    {
+      "name": "list-email-campaigns",
+      "description": "List the account's email campaigns, newest first, with optional search by name."
+    },
+    {
+      "name": "get-email-campaign",
+      "description": "Get a single email campaign."
+    },
+    {
+      "name": "create-email-campaign",
+      "description": "Create a draft email campaign for a verified sending domain."
+    },
+    {
+      "name": "update-email-campaign",
+      "description": "Update a draft email campaign and its template."
+    },
+    {
+      "name": "delete-email-campaign",
+      "description": "Delete a draft email campaign."
+    },
+    {
+      "name": "start-email-campaign",
+      "description": "Start sending a draft email campaign immediately."
+    },
+    {
+      "name": "schedule-email-campaign",
+      "description": "Schedule a draft email campaign to start sending at a future time."
+    },
+    {
+      "name": "cancel-email-campaign",
+      "description": "Cancel a scheduled email campaign, returning it to draft."
+    },
+    {
+      "name": "terminate-email-campaign",
+      "description": "Terminate a campaign that is currently sending, aborting the send."
+    },
+    {
+      "name": "reset-email-campaign",
+      "description": "Reset a scheduled email campaign back to draft."
+    },
+    {
+      "name": "get-email-campaign-stats",
+      "description": "Get the performance statistics of an email campaign, optionally for a date range."
+    },
+    {
+      "name": "list-accounts",
+      "description": "List the Mailtrap accounts the API token can access, with their access levels."
+    },
+    {
+      "name": "get-billing-usage",
+      "description": "Get the current billing cycle's plans, limits, and usage."
+    },
+    {
+      "name": "list-account-accesses",
+      "description": "List the users, invites, and API tokens with access to the account."
+    },
+    {
+      "name": "remove-account-access",
+      "description": "Revoke a user's permissions, or delete an invite or API token."
+    },
+    {
+      "name": "get-permission-resources",
+      "description": "List the inboxes, projects, domains, and billing resources the token administers."
+    },
+    {
+      "name": "bulk-update-permissions",
+      "description": "Create, update, or remove several permissions on an account access in one call."
+    },
+    {
+      "name": "list-api-tokens",
+      "description": "List the API tokens on the account."
+    },
+    {
+      "name": "create-api-token",
+      "description": "Create an API token; the secret value is returned only on creation."
+    },
+    {
+      "name": "get-api-token",
+      "description": "Get an API token's metadata; the secret value is not returned."
+    },
+    {
+      "name": "reset-api-token",
+      "description": "Rotate an API token, invalidating the previous secret value."
+    },
+    {
+      "name": "delete-api-token",
+      "description": "Permanently delete an API token."
+    },
+    {
+      "name": "list-sub-accounts",
+      "description": "List the sub-accounts in the organization."
+    },
+    {
+      "name": "create-sub-account",
+      "description": "Create a new sub-account under the organization."
+    },
+    {
+      "name": "list-inbound-folders",
+      "description": "List the inbound folders on the account."
+    },
+    {
+      "name": "get-inbound-folder",
+      "description": "Get a single inbound folder."
+    },
+    {
+      "name": "create-inbound-folder",
+      "description": "Create a new inbound folder to group inboxes."
+    },
+    {
+      "name": "update-inbound-folder",
+      "description": "Rename an inbound folder."
+    },
+    {
+      "name": "delete-inbound-folder",
+      "description": "Delete an inbound folder and all the inboxes it contains."
+    },
+    {
+      "name": "list-inbound-inboxes",
+      "description": "List the inbound inboxes in a folder."
+    },
+    {
+      "name": "get-inbound-inbox",
+      "description": "Get a single inbound inbox and its receiving address."
+    },
+    {
+      "name": "create-inbound-inbox",
+      "description": "Create a Mailtrap-hosted or custom-domain inbound inbox."
+    },
+    {
+      "name": "update-inbound-inbox",
+      "description": "Update an inbound inbox's settings."
+    },
+    {
+      "name": "delete-inbound-inbox",
+      "description": "Delete an inbound inbox and the messages it holds."
+    },
+    {
+      "name": "list-inbound-messages",
+      "description": "List the messages received in an inbound inbox."
+    },
+    {
+      "name": "get-inbound-message",
+      "description": "Get a received message with its body and attachment download URLs."
+    },
+    {
+      "name": "delete-inbound-message",
+      "description": "Delete a received message."
+    },
+    {
+      "name": "reply-to-inbound-message",
+      "description": "Reply to a received message, sending real email to its sender."
+    },
+    {
+      "name": "reply-all-to-inbound-message",
+      "description": "Reply to a received message and all its recipients, sending real email."
+    },
+    {
+      "name": "forward-inbound-message",
+      "description": "Forward a received message to other recipients, sending real email."
+    },
+    {
+      "name": "list-inbound-threads",
+      "description": "List the conversation threads in an inbound inbox."
+    },
+    {
+      "name": "get-inbound-thread",
+      "description": "Get a conversation thread and the messages it contains."
+    },
+    {
+      "name": "delete-inbound-thread",
+      "description": "Delete a conversation thread and its messages."
     }
   ],
   "prompts": [],

--- a/manifest.json
+++ b/manifest.json
@@ -123,8 +123,40 @@
       "description": "Create a new sending domain."
     },
     {
+      "name": "update-sending-domain",
+      "description": "Update a sending domain's tracking and inbound settings."
+    },
+    {
       "name": "delete-sending-domain",
       "description": "Delete a sending domain."
+    },
+    {
+      "name": "get-company-info",
+      "description": "Get the company info of a sending domain, used for domain compliance verification."
+    },
+    {
+      "name": "create-company-info",
+      "description": "Set the company info of a sending domain, required for domain compliance verification."
+    },
+    {
+      "name": "update-company-info",
+      "description": "Update the company info of a sending domain."
+    },
+    {
+      "name": "create-suppression",
+      "description": "Add an email address to the account's suppression list, so Mailtrap stops delivering to it."
+    },
+    {
+      "name": "list-tracking-opt-outs",
+      "description": "List email addresses excluded from open and click tracking. Returns up to 1000 records per call."
+    },
+    {
+      "name": "create-tracking-opt-out",
+      "description": "Exclude an email address from open and click tracking for a sending domain."
+    },
+    {
+      "name": "delete-tracking-opt-out",
+      "description": "Remove an email address from the tracking opt-out list, so open and click tracking applies to it again."
     }
   ],
   "prompts": [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@modelcontextprotocol/sdk": "^1.18.2",
         "dotenv": "^16.4.7",
         "mailsplit": "^5.4.6",
-        "mailtrap": "^4.9.0",
+        "mailtrap": "^4.10.0",
         "zod": "^3.24.2"
       },
       "bin": {
@@ -676,9 +676,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -787,9 +787,9 @@
       "license": "MIT"
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1123,9 +1123,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4872,9 +4872,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4988,9 +4988,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5410,9 +5410,9 @@
       "license": "MIT"
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5828,9 +5828,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6824,9 +6824,9 @@
       "license": "MIT"
     },
     "node_modules/jake/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7431,9 +7431,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {
@@ -7689,9 +7689,9 @@
       }
     },
     "node_modules/mailtrap": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/mailtrap/-/mailtrap-4.9.0.tgz",
-      "integrity": "sha512-I21Q8DNt98xy5vExQVPWIoudp3DuhzsyPEvLKhp26lkLKoRlEUAwgswJcqSJtCD9MP1RC/E+gL9ER7UdJ4sE6g==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/mailtrap/-/mailtrap-4.10.0.tgz",
+      "integrity": "sha512-WgLKOmgy8HhvjXMb4S+E2NVjgJLbDUC17lMFKsKNwBxTBteD2sin2m2wuEVbdppluq5YL5A1saNhSW8FvUdm/g==",
       "license": "MIT",
       "dependencies": {
         "axios": ">=0.27",
@@ -7856,9 +7856,9 @@
       }
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9176,9 +9176,9 @@
       "license": "MIT"
     },
     "node_modules/serve-handler/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9755,9 +9755,9 @@
       "license": "MIT"
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -39,14 +39,14 @@
     "@modelcontextprotocol/sdk": "^1.18.2",
     "dotenv": "^16.4.7",
     "mailsplit": "^5.4.6",
-    "mailtrap": "^4.9.0",
+    "mailtrap": "^4.10.0",
     "zod": "^3.24.2"
   },
   "overrides": {
     "@typescript-eslint/typescript-estree": {
       "minimatch": {
         ".": "9.0.7",
-        "brace-expansion": "5.0.8"
+        "brace-expansion": "5.0.9"
       }
     },
     "@hono/node-server": "2.0.11",

--- a/src/server.ts
+++ b/src/server.ts
@@ -115,6 +115,8 @@ import {
   getCompanyInfoSchema,
   createCompanyInfo,
   createCompanyInfoSchema,
+  updateCompanyInfo,
+  updateCompanyInfoSchema,
 } from "./tools/companyInfo";
 import {
   listSuppressions,
@@ -760,6 +762,15 @@ const tools = [
     handler: createCompanyInfo,
     annotations: {
       destructiveHint: false,
+    },
+  },
+  {
+    name: "update-company-info",
+    description: "Update the company info of a sending domain.",
+    inputSchema: updateCompanyInfoSchema,
+    handler: updateCompanyInfo,
+    annotations: {
+      destructiveHint: true,
     },
   },
   {

--- a/src/server.ts
+++ b/src/server.ts
@@ -121,6 +121,8 @@ import {
 import {
   listSuppressions,
   listSuppressionsSchema,
+  createSuppression,
+  createSuppressionSchema,
   deleteSuppression,
   deleteSuppressionSchema,
 } from "./tools/suppressions";
@@ -781,6 +783,16 @@ const tools = [
     handler: listSuppressions,
     annotations: {
       readOnlyHint: true,
+    },
+  },
+  {
+    name: "create-suppression",
+    description:
+      "Add an email address to the account's suppression list, so Mailtrap stops delivering to it.",
+    inputSchema: createSuppressionSchema,
+    handler: createSuppression,
+    annotations: {
+      destructiveHint: false,
     },
   },
   {

--- a/src/server.ts
+++ b/src/server.ts
@@ -110,6 +110,7 @@ import {
   sendSendingDomainSetupInstructions,
   sendSendingDomainSetupInstructionsSchema,
 } from "./tools/sendingDomains";
+import { getCompanyInfo, getCompanyInfoSchema } from "./tools/companyInfo";
 import {
   listSuppressions,
   listSuppressionsSchema,
@@ -734,6 +735,16 @@ const tools = [
     handler: sendSendingDomainSetupInstructions,
     annotations: {
       destructiveHint: false,
+    },
+  },
+  {
+    name: "get-company-info",
+    description:
+      "Get the company info of a sending domain, used for domain compliance verification.",
+    inputSchema: getCompanyInfoSchema,
+    handler: getCompanyInfo,
+    annotations: {
+      readOnlyHint: true,
     },
   },
   {

--- a/src/server.ts
+++ b/src/server.ts
@@ -103,6 +103,8 @@ import {
   getSendingDomainSchema,
   createSendingDomain,
   createSendingDomainSchema,
+  updateSendingDomain,
+  updateSendingDomainSchema,
   deleteSendingDomain,
   deleteSendingDomainSchema,
   sendSendingDomainSetupInstructions,
@@ -704,6 +706,15 @@ const tools = [
     handler: createSendingDomain,
     annotations: {
       destructiveHint: false,
+    },
+  },
+  {
+    name: "update-sending-domain",
+    description: "Update a sending domain's tracking and inbound settings.",
+    inputSchema: updateSendingDomainSchema,
+    handler: updateSendingDomain,
+    annotations: {
+      destructiveHint: true,
     },
   },
   {

--- a/src/server.ts
+++ b/src/server.ts
@@ -131,6 +131,8 @@ import {
   listTrackingOptOutsSchema,
   createTrackingOptOut,
   createTrackingOptOutSchema,
+  deleteTrackingOptOut,
+  deleteTrackingOptOutSchema,
 } from "./tools/trackingOptOuts";
 import {
   listWebhooks,
@@ -829,6 +831,16 @@ const tools = [
     handler: createTrackingOptOut,
     annotations: {
       destructiveHint: false,
+    },
+  },
+  {
+    name: "delete-tracking-opt-out",
+    description:
+      "Remove an email address from the tracking opt-out list, so open and click tracking applies to it again.",
+    inputSchema: deleteTrackingOptOutSchema,
+    handler: deleteTrackingOptOut,
+    annotations: {
+      destructiveHint: true,
     },
   },
   {

--- a/src/server.ts
+++ b/src/server.ts
@@ -110,7 +110,12 @@ import {
   sendSendingDomainSetupInstructions,
   sendSendingDomainSetupInstructionsSchema,
 } from "./tools/sendingDomains";
-import { getCompanyInfo, getCompanyInfoSchema } from "./tools/companyInfo";
+import {
+  getCompanyInfo,
+  getCompanyInfoSchema,
+  createCompanyInfo,
+  createCompanyInfoSchema,
+} from "./tools/companyInfo";
 import {
   listSuppressions,
   listSuppressionsSchema,
@@ -745,6 +750,16 @@ const tools = [
     handler: getCompanyInfo,
     annotations: {
       readOnlyHint: true,
+    },
+  },
+  {
+    name: "create-company-info",
+    description:
+      "Set the company info of a sending domain, required for domain compliance verification.",
+    inputSchema: createCompanyInfoSchema,
+    handler: createCompanyInfo,
+    annotations: {
+      destructiveHint: false,
     },
   },
   {

--- a/src/server.ts
+++ b/src/server.ts
@@ -129,6 +129,8 @@ import {
 import {
   listTrackingOptOuts,
   listTrackingOptOutsSchema,
+  createTrackingOptOut,
+  createTrackingOptOutSchema,
 } from "./tools/trackingOptOuts";
 import {
   listWebhooks,
@@ -817,6 +819,16 @@ const tools = [
     handler: listTrackingOptOuts,
     annotations: {
       readOnlyHint: true,
+    },
+  },
+  {
+    name: "create-tracking-opt-out",
+    description:
+      "Exclude an email address from open and click tracking for a sending domain.",
+    inputSchema: createTrackingOptOutSchema,
+    handler: createTrackingOptOut,
+    annotations: {
+      destructiveHint: false,
     },
   },
   {

--- a/src/server.ts
+++ b/src/server.ts
@@ -127,6 +127,10 @@ import {
   deleteSuppressionSchema,
 } from "./tools/suppressions";
 import {
+  listTrackingOptOuts,
+  listTrackingOptOutsSchema,
+} from "./tools/trackingOptOuts";
+import {
   listWebhooks,
   listWebhooksSchema,
   getWebhook,
@@ -803,6 +807,16 @@ const tools = [
     handler: deleteSuppression,
     annotations: {
       destructiveHint: true,
+    },
+  },
+  {
+    name: "list-tracking-opt-outs",
+    description:
+      "List email addresses excluded from open and click tracking. Returns up to 1000 records per call.",
+    inputSchema: listTrackingOptOutsSchema,
+    handler: listTrackingOptOuts,
+    annotations: {
+      readOnlyHint: true,
     },
   },
   {

--- a/src/tools/companyInfo/__tests__/createCompanyInfo.test.ts
+++ b/src/tools/companyInfo/__tests__/createCompanyInfo.test.ts
@@ -1,0 +1,112 @@
+import createCompanyInfo from "../createCompanyInfo";
+import { requireClient } from "../../../client";
+
+const mockClient = {
+  companyInfo: {
+    create: jest.fn(),
+  },
+};
+
+jest.mock("../../../client", () => ({
+  requireClient: jest.fn(() => mockClient),
+}));
+
+const requiredParams = {
+  name: "Mailtrap",
+  address: "123 Main St",
+  city: "San Francisco",
+  country: "US",
+  zip_code: "94105",
+  website_url: "https://mailtrap.io",
+};
+
+describe("createCompanyInfo", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (requireClient as jest.Mock).mockReturnValue(mockClient);
+  });
+
+  it("creates the company info without the domain id in the body", async () => {
+    mockClient.companyInfo.create.mockResolvedValue({
+      data: { ...requiredParams, info_level: "business" },
+    });
+
+    const result = await createCompanyInfo({
+      sending_domain_id: 4321,
+      ...requiredParams,
+    });
+
+    expect(requireClient).toHaveBeenCalledWith("company info", {
+      requireAccountId: false,
+    });
+    expect(mockClient.companyInfo.create).toHaveBeenCalledWith(
+      4321,
+      requiredParams
+    );
+    expect(JSON.parse(result.content[0].text).name).toBe("Mailtrap");
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("forwards the optional fields", async () => {
+    mockClient.companyInfo.create.mockResolvedValue({ data: requiredParams });
+
+    await createCompanyInfo({
+      sending_domain_id: 4321,
+      ...requiredParams,
+      phone: "+1 555 0100",
+      privacy_policy_url: "https://mailtrap.io/privacy",
+      terms_of_service_url: "https://mailtrap.io/terms",
+      info_level: "individual",
+    });
+
+    expect(mockClient.companyInfo.create).toHaveBeenCalledWith(4321, {
+      ...requiredParams,
+      phone: "+1 555 0100",
+      privacy_policy_url: "https://mailtrap.io/privacy",
+      terms_of_service_url: "https://mailtrap.io/terms",
+      info_level: "individual",
+    });
+  });
+
+  it("rejects a missing required field", async () => {
+    const withoutCity = { ...requiredParams };
+    delete (withoutCity as Partial<typeof requiredParams>).city;
+
+    const result = await createCompanyInfo({
+      sending_domain_id: 4321,
+      ...withoutCity,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("city");
+    expect(mockClient.companyInfo.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unknown info level", async () => {
+    const result = await createCompanyInfo({
+      sending_domain_id: 4321,
+      ...requiredParams,
+      info_level: "enterprise",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("info_level");
+    expect(mockClient.companyInfo.create).not.toHaveBeenCalled();
+  });
+
+  it("surfaces API errors", async () => {
+    mockClient.companyInfo.create.mockRejectedValue(
+      new Error("already exists")
+    );
+
+    const result = await createCompanyInfo({
+      sending_domain_id: 4321,
+      ...requiredParams,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe(
+      "Failed to create company info: already exists"
+    );
+  });
+});

--- a/src/tools/companyInfo/__tests__/getCompanyInfo.test.ts
+++ b/src/tools/companyInfo/__tests__/getCompanyInfo.test.ts
@@ -1,0 +1,52 @@
+import getCompanyInfo from "../getCompanyInfo";
+import { requireClient } from "../../../client";
+
+const mockClient = {
+  companyInfo: {
+    get: jest.fn(),
+  },
+};
+
+jest.mock("../../../client", () => ({
+  requireClient: jest.fn(() => mockClient),
+}));
+
+describe("getCompanyInfo", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (requireClient as jest.Mock).mockReturnValue(mockClient);
+  });
+
+  it("returns the company info", async () => {
+    const companyInfo = {
+      name: "Mailtrap",
+      address: "123 Main St",
+      city: "San Francisco",
+      country: "US",
+      zip_code: "94105",
+      website_url: "https://mailtrap.io",
+      info_level: "business",
+    };
+    mockClient.companyInfo.get.mockResolvedValue({ data: companyInfo });
+
+    const result = await getCompanyInfo({ sending_domain_id: 4321 });
+
+    expect(requireClient).toHaveBeenCalledWith("company info", {
+      requireAccountId: false,
+    });
+    expect(mockClient.companyInfo.get).toHaveBeenCalledWith(4321);
+    expect(JSON.parse(result.content[0].text)).toEqual(companyInfo);
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("surfaces API errors", async () => {
+    mockClient.companyInfo.get.mockRejectedValue(new Error("not found"));
+
+    const result = await getCompanyInfo({ sending_domain_id: 4321 });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe(
+      "Failed to get company info: not found"
+    );
+  });
+});

--- a/src/tools/companyInfo/__tests__/updateCompanyInfo.test.ts
+++ b/src/tools/companyInfo/__tests__/updateCompanyInfo.test.ts
@@ -1,0 +1,75 @@
+import updateCompanyInfo from "../updateCompanyInfo";
+import { requireClient } from "../../../client";
+
+const mockClient = {
+  companyInfo: {
+    update: jest.fn(),
+  },
+};
+
+jest.mock("../../../client", () => ({
+  requireClient: jest.fn(() => mockClient),
+}));
+
+describe("updateCompanyInfo", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (requireClient as jest.Mock).mockReturnValue(mockClient);
+  });
+
+  it("sends only the fields provided", async () => {
+    mockClient.companyInfo.update.mockResolvedValue({
+      data: { city: "New York", zip_code: "10001" },
+    });
+
+    const result = await updateCompanyInfo({
+      sending_domain_id: 4321,
+      city: "New York",
+      zip_code: "10001",
+    });
+
+    expect(requireClient).toHaveBeenCalledWith("company info", {
+      requireAccountId: false,
+    });
+    expect(mockClient.companyInfo.update).toHaveBeenCalledWith(4321, {
+      city: "New York",
+      zip_code: "10001",
+    });
+    expect(JSON.parse(result.content[0].text).city).toBe("New York");
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("rejects an update with no fields", async () => {
+    const result = await updateCompanyInfo({ sending_domain_id: 4321 });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain(
+      "Provide at least one field to update."
+    );
+    expect(mockClient.companyInfo.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects unknown properties", async () => {
+    const result = await updateCompanyInfo({
+      sending_domain_id: 4321,
+      company_name: "Mailtrap",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(mockClient.companyInfo.update).not.toHaveBeenCalled();
+  });
+
+  it("surfaces API errors", async () => {
+    mockClient.companyInfo.update.mockRejectedValue(new Error("not found"));
+
+    const result = await updateCompanyInfo({
+      sending_domain_id: 4321,
+      city: "New York",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe(
+      "Failed to update company info: not found"
+    );
+  });
+});

--- a/src/tools/companyInfo/createCompanyInfo.ts
+++ b/src/tools/companyInfo/createCompanyInfo.ts
@@ -1,0 +1,36 @@
+import { requireClient } from "../../client";
+import {
+  buildErrorResponse,
+  buildSuccessResponse,
+  ToolResponse,
+} from "../utils/responses";
+import { createCompanyInfoZod } from "./schemas/createCompanyInfo";
+
+async function createCompanyInfo(raw: unknown): Promise<ToolResponse> {
+  try {
+    const parsed = createCompanyInfoZod.safeParse(raw ?? {});
+    if (!parsed.success) {
+      const msg = parsed.error.errors
+        .map((e) => `${e.path.join(".")}: ${e.message}`)
+        .join("; ");
+      return {
+        content: [{ type: "text", text: `Invalid input: ${msg}` }],
+        isError: true,
+      };
+    }
+
+    const { sending_domain_id: sendingDomainId, ...params } = parsed.data;
+
+    const mailtrap = requireClient("company info", {
+      requireAccountId: false,
+    });
+
+    const response = await mailtrap.companyInfo.create(sendingDomainId, params);
+
+    return buildSuccessResponse(JSON.stringify(response.data, null, 2));
+  } catch (error) {
+    return buildErrorResponse("create company info", error);
+  }
+}
+
+export default createCompanyInfo;

--- a/src/tools/companyInfo/getCompanyInfo.ts
+++ b/src/tools/companyInfo/getCompanyInfo.ts
@@ -1,0 +1,25 @@
+import { requireClient } from "../../client";
+import { GetCompanyInfoRequest } from "../../types/mailtrap";
+import {
+  buildErrorResponse,
+  buildSuccessResponse,
+  ToolResponse,
+} from "../utils/responses";
+
+async function getCompanyInfo({
+  sending_domain_id,
+}: GetCompanyInfoRequest): Promise<ToolResponse> {
+  try {
+    const mailtrap = requireClient("company info", {
+      requireAccountId: false,
+    });
+
+    const response = await mailtrap.companyInfo.get(sending_domain_id);
+
+    return buildSuccessResponse(JSON.stringify(response.data, null, 2));
+  } catch (error) {
+    return buildErrorResponse("get company info", error);
+  }
+}
+
+export default getCompanyInfo;

--- a/src/tools/companyInfo/index.ts
+++ b/src/tools/companyInfo/index.ts
@@ -2,10 +2,14 @@ import getCompanyInfoSchema from "./schemas/getCompanyInfo";
 import getCompanyInfo from "./getCompanyInfo";
 import createCompanyInfoSchema from "./schemas/createCompanyInfo";
 import createCompanyInfo from "./createCompanyInfo";
+import updateCompanyInfoSchema from "./schemas/updateCompanyInfo";
+import updateCompanyInfo from "./updateCompanyInfo";
 
 export {
   getCompanyInfoSchema,
   getCompanyInfo,
   createCompanyInfoSchema,
   createCompanyInfo,
+  updateCompanyInfoSchema,
+  updateCompanyInfo,
 };

--- a/src/tools/companyInfo/index.ts
+++ b/src/tools/companyInfo/index.ts
@@ -1,0 +1,4 @@
+import getCompanyInfoSchema from "./schemas/getCompanyInfo";
+import getCompanyInfo from "./getCompanyInfo";
+
+export { getCompanyInfoSchema, getCompanyInfo };

--- a/src/tools/companyInfo/index.ts
+++ b/src/tools/companyInfo/index.ts
@@ -1,4 +1,11 @@
 import getCompanyInfoSchema from "./schemas/getCompanyInfo";
 import getCompanyInfo from "./getCompanyInfo";
+import createCompanyInfoSchema from "./schemas/createCompanyInfo";
+import createCompanyInfo from "./createCompanyInfo";
 
-export { getCompanyInfoSchema, getCompanyInfo };
+export {
+  getCompanyInfoSchema,
+  getCompanyInfo,
+  createCompanyInfoSchema,
+  createCompanyInfo,
+};

--- a/src/tools/companyInfo/schemas/createCompanyInfo.ts
+++ b/src/tools/companyInfo/schemas/createCompanyInfo.ts
@@ -1,0 +1,81 @@
+import { z } from "zod";
+
+const createCompanyInfoSchema = {
+  type: "object",
+  properties: {
+    sending_domain_id: {
+      type: "integer",
+      minimum: 1,
+      description: "Sending domain ID",
+    },
+    name: {
+      type: "string",
+      description: "Company or individual name.",
+    },
+    address: {
+      type: "string",
+      description: "Street address.",
+    },
+    city: {
+      type: "string",
+      description: "City.",
+    },
+    country: {
+      type: "string",
+      description: "Country.",
+    },
+    zip_code: {
+      type: "string",
+      description: "ZIP or postal code.",
+    },
+    website_url: {
+      type: "string",
+      description: "Company website URL.",
+    },
+    phone: {
+      type: "string",
+      description: "Phone number.",
+    },
+    privacy_policy_url: {
+      type: "string",
+      description: "URL of the privacy policy page.",
+    },
+    terms_of_service_url: {
+      type: "string",
+      description: "URL of the terms of service page.",
+    },
+    info_level: {
+      type: "string",
+      enum: ["business", "individual"],
+      description: "Whether the sender is a business or an individual.",
+    },
+  },
+  required: [
+    "sending_domain_id",
+    "name",
+    "address",
+    "city",
+    "country",
+    "zip_code",
+    "website_url",
+  ],
+  additionalProperties: false,
+};
+
+export const createCompanyInfoZod = z
+  .object({
+    sending_domain_id: z.number().int().min(1),
+    name: z.string().min(1),
+    address: z.string().min(1),
+    city: z.string().min(1),
+    country: z.string().min(1),
+    zip_code: z.string().min(1),
+    website_url: z.string().min(1),
+    phone: z.string().optional(),
+    privacy_policy_url: z.string().optional(),
+    terms_of_service_url: z.string().optional(),
+    info_level: z.enum(["business", "individual"]).optional(),
+  })
+  .strict();
+
+export default createCompanyInfoSchema;

--- a/src/tools/companyInfo/schemas/getCompanyInfo.ts
+++ b/src/tools/companyInfo/schemas/getCompanyInfo.ts
@@ -1,0 +1,14 @@
+const getCompanyInfoSchema = {
+  type: "object",
+  properties: {
+    sending_domain_id: {
+      type: "integer",
+      minimum: 1,
+      description: "Sending domain ID",
+    },
+  },
+  required: ["sending_domain_id"],
+  additionalProperties: false,
+};
+
+export default getCompanyInfoSchema;

--- a/src/tools/companyInfo/schemas/updateCompanyInfo.ts
+++ b/src/tools/companyInfo/schemas/updateCompanyInfo.ts
@@ -1,0 +1,80 @@
+import { z } from "zod";
+
+const updateCompanyInfoSchema = {
+  type: "object",
+  properties: {
+    sending_domain_id: {
+      type: "integer",
+      minimum: 1,
+      description: "Sending domain ID",
+    },
+    name: {
+      type: "string",
+      description: "Company or individual name.",
+    },
+    address: {
+      type: "string",
+      description: "Street address.",
+    },
+    city: {
+      type: "string",
+      description: "City.",
+    },
+    country: {
+      type: "string",
+      description: "Country.",
+    },
+    zip_code: {
+      type: "string",
+      description: "ZIP or postal code.",
+    },
+    website_url: {
+      type: "string",
+      description: "Company website URL.",
+    },
+    phone: {
+      type: "string",
+      description: "Phone number.",
+    },
+    privacy_policy_url: {
+      type: "string",
+      description: "URL of the privacy policy page.",
+    },
+    terms_of_service_url: {
+      type: "string",
+      description: "URL of the terms of service page.",
+    },
+    info_level: {
+      type: "string",
+      enum: ["business", "individual"],
+      description: "Whether the sender is a business or an individual.",
+    },
+  },
+  required: ["sending_domain_id"],
+  additionalProperties: false,
+  description:
+    "At least one field besides `sending_domain_id` must be provided. Fields left out are unchanged.",
+};
+
+export const updateCompanyInfoZod = z
+  .object({
+    sending_domain_id: z.number().int().min(1),
+    name: z.string().optional(),
+    address: z.string().optional(),
+    city: z.string().optional(),
+    country: z.string().optional(),
+    zip_code: z.string().optional(),
+    website_url: z.string().optional(),
+    phone: z.string().optional(),
+    privacy_policy_url: z.string().optional(),
+    terms_of_service_url: z.string().optional(),
+    info_level: z.enum(["business", "individual"]).optional(),
+  })
+  .strict()
+  .refine(
+    ({ sending_domain_id: _sendingDomainId, ...updates }) =>
+      Object.keys(updates).length > 0,
+    { message: "Provide at least one field to update." }
+  );
+
+export default updateCompanyInfoSchema;

--- a/src/tools/companyInfo/updateCompanyInfo.ts
+++ b/src/tools/companyInfo/updateCompanyInfo.ts
@@ -1,0 +1,36 @@
+import { requireClient } from "../../client";
+import {
+  buildErrorResponse,
+  buildSuccessResponse,
+  ToolResponse,
+} from "../utils/responses";
+import { updateCompanyInfoZod } from "./schemas/updateCompanyInfo";
+
+async function updateCompanyInfo(raw: unknown): Promise<ToolResponse> {
+  try {
+    const parsed = updateCompanyInfoZod.safeParse(raw ?? {});
+    if (!parsed.success) {
+      const msg = parsed.error.errors
+        .map((e) => `${e.path.join(".")}: ${e.message}`)
+        .join("; ");
+      return {
+        content: [{ type: "text", text: `Invalid input: ${msg}` }],
+        isError: true,
+      };
+    }
+
+    const { sending_domain_id: sendingDomainId, ...params } = parsed.data;
+
+    const mailtrap = requireClient("company info", {
+      requireAccountId: false,
+    });
+
+    const response = await mailtrap.companyInfo.update(sendingDomainId, params);
+
+    return buildSuccessResponse(JSON.stringify(response.data, null, 2));
+  } catch (error) {
+    return buildErrorResponse("update company info", error);
+  }
+}
+
+export default updateCompanyInfo;

--- a/src/tools/permissions/__tests__/bulkUpdatePermissions.test.ts
+++ b/src/tools/permissions/__tests__/bulkUpdatePermissions.test.ts
@@ -41,7 +41,7 @@ describe("bulkUpdatePermissions", () => {
       mockClient.general.permissions.bulkPermissionsUpdate
     ).toHaveBeenCalledWith(42, [
       { resourceId: "100", resourceType: "project", accessLevel: "100" },
-      { resourceId: "uuid-1", resourceType: "domain", destroy: "true" },
+      { resourceId: "uuid-1", resourceType: "domain", destroy: true },
     ]);
     expect(result.content[0].text).toContain('"access_level": 100');
     expect(result.isError).toBeUndefined();

--- a/src/tools/permissions/bulkUpdatePermissions.ts
+++ b/src/tools/permissions/bulkUpdatePermissions.ts
@@ -19,7 +19,7 @@ async function bulkUpdatePermissions({
       ...(p.access_level !== undefined && {
         accessLevel: String(p.access_level),
       }),
-      ...(p.destroy !== undefined && { destroy: String(p.destroy) }),
+      ...(p.destroy !== undefined && { destroy: p.destroy }),
     }));
 
     const response = await mailtrap.general.permissions.bulkPermissionsUpdate(

--- a/src/tools/sendingDomains/__tests__/updateSendingDomain.test.ts
+++ b/src/tools/sendingDomains/__tests__/updateSendingDomain.test.ts
@@ -1,0 +1,98 @@
+import updateSendingDomain from "../updateSendingDomain";
+import { requireClient } from "../../../client";
+
+const mockClient = {
+  sendingDomains: {
+    update: jest.fn(),
+  },
+};
+
+jest.mock("../../../client", () => ({
+  requireClient: jest.fn(() => mockClient),
+}));
+
+const updatedDomain = {
+  id: 4321,
+  domain_name: "example.com",
+  open_tracking_enabled: true,
+  click_tracking_enabled: true,
+  tracking_opt_out_enabled: true,
+  auto_unsubscribe_link_enabled: false,
+  inbound_enabled: false,
+};
+
+describe("updateSendingDomain", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (requireClient as jest.Mock).mockReturnValue(mockClient);
+  });
+
+  it("sends only the settings provided and reports every setting back", async () => {
+    mockClient.sendingDomains.update.mockResolvedValue(updatedDomain);
+
+    const result = await updateSendingDomain({
+      sending_domain_id: 4321,
+      open_tracking_enabled: true,
+      tracking_opt_out_enabled: true,
+    });
+
+    expect(requireClient).toHaveBeenCalledWith("sending domains");
+    expect(mockClient.sendingDomains.update).toHaveBeenCalledWith(4321, {
+      open_tracking_enabled: true,
+      tracking_opt_out_enabled: true,
+    });
+    expect(result.content[0].text).toContain(
+      "Sending domain example.com (ID: 4321) updated."
+    );
+    expect(result.content[0].text).toContain("Tracking opt-out link: true");
+    expect(result.content[0].text).toContain("Auto unsubscribe link: false");
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("forwards a setting turned off", async () => {
+    mockClient.sendingDomains.update.mockResolvedValue(updatedDomain);
+
+    await updateSendingDomain({
+      sending_domain_id: 4321,
+      click_tracking_enabled: false,
+    });
+
+    expect(mockClient.sendingDomains.update).toHaveBeenCalledWith(4321, {
+      click_tracking_enabled: false,
+    });
+  });
+
+  it("rejects an update with no settings", async () => {
+    const result = await updateSendingDomain({ sending_domain_id: 4321 });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain(
+      "Provide at least one setting to update."
+    );
+    expect(mockClient.sendingDomains.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects unknown properties", async () => {
+    const result = await updateSendingDomain({
+      sending_domain_id: 4321,
+      open_tracking: true,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(mockClient.sendingDomains.update).not.toHaveBeenCalled();
+  });
+
+  it("surfaces API errors", async () => {
+    mockClient.sendingDomains.update.mockRejectedValue(new Error("not found"));
+
+    const result = await updateSendingDomain({
+      sending_domain_id: 4321,
+      inbound_enabled: true,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe(
+      "Failed to update sending domain: not found"
+    );
+  });
+});

--- a/src/tools/sendingDomains/index.ts
+++ b/src/tools/sendingDomains/index.ts
@@ -2,12 +2,14 @@ import {
   listSendingDomainsSchema,
   getSendingDomainSchema,
   createSendingDomainSchema,
+  updateSendingDomainSchema,
   deleteSendingDomainSchema,
   sendSendingDomainSetupInstructionsSchema,
 } from "./schema";
 import listSendingDomains from "./listSendingDomains";
 import getSendingDomain from "./getSendingDomain";
 import createSendingDomain from "./createSendingDomain";
+import updateSendingDomain from "./updateSendingDomain";
 import deleteSendingDomain from "./deleteSendingDomain";
 import sendSendingDomainSetupInstructions from "./sendSetupInstructions";
 
@@ -18,6 +20,8 @@ export {
   getSendingDomain,
   createSendingDomainSchema,
   createSendingDomain,
+  updateSendingDomainSchema,
+  updateSendingDomain,
   deleteSendingDomainSchema,
   deleteSendingDomain,
   sendSendingDomainSetupInstructionsSchema,

--- a/src/tools/sendingDomains/schema.ts
+++ b/src/tools/sendingDomains/schema.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 const listSendingDomainsSchema = {
   type: "object",
   properties: {},
@@ -62,10 +64,64 @@ const sendSendingDomainSetupInstructionsSchema = {
   additionalProperties: false,
 };
 
+const updateSendingDomainSchema = {
+  type: "object",
+  properties: {
+    sending_domain_id: {
+      type: "integer",
+      minimum: 1,
+      description: "Sending domain ID",
+    },
+    open_tracking_enabled: {
+      type: "boolean",
+      description: "Track opens on emails sent from this domain.",
+    },
+    click_tracking_enabled: {
+      type: "boolean",
+      description: "Track clicks on links in emails sent from this domain.",
+    },
+    tracking_opt_out_enabled: {
+      type: "boolean",
+      description:
+        "Add the tracking opt-out link to tracked emails. Requires open or click tracking.",
+    },
+    auto_unsubscribe_link_enabled: {
+      type: "boolean",
+      description: "Automatically add an unsubscribe link to emails.",
+    },
+    inbound_enabled: {
+      type: "boolean",
+      description:
+        "Allow the domain to be attached to an inbound inbox as a catch-all.",
+    },
+  },
+  required: ["sending_domain_id"],
+  additionalProperties: false,
+  description:
+    "At least one setting besides `sending_domain_id` must be provided. Settings left out are unchanged.",
+};
+
+export const updateSendingDomainZod = z
+  .object({
+    sending_domain_id: z.number().int().min(1),
+    open_tracking_enabled: z.boolean().optional(),
+    click_tracking_enabled: z.boolean().optional(),
+    tracking_opt_out_enabled: z.boolean().optional(),
+    auto_unsubscribe_link_enabled: z.boolean().optional(),
+    inbound_enabled: z.boolean().optional(),
+  })
+  .strict()
+  .refine(
+    ({ sending_domain_id: _sendingDomainId, ...updates }) =>
+      Object.keys(updates).length > 0,
+    { message: "Provide at least one setting to update." }
+  );
+
 export {
   listSendingDomainsSchema,
   getSendingDomainSchema,
   createSendingDomainSchema,
+  updateSendingDomainSchema,
   deleteSendingDomainSchema,
   sendSendingDomainSetupInstructionsSchema,
 };

--- a/src/tools/sendingDomains/updateSendingDomain.ts
+++ b/src/tools/sendingDomains/updateSendingDomain.ts
@@ -1,0 +1,46 @@
+import { requireClient } from "../../client";
+import {
+  buildErrorResponse,
+  buildSuccessResponse,
+  ToolResponse,
+} from "../utils/responses";
+import { updateSendingDomainZod } from "./schema";
+
+async function updateSendingDomain(raw: unknown): Promise<ToolResponse> {
+  try {
+    const parsed = updateSendingDomainZod.safeParse(raw ?? {});
+    if (!parsed.success) {
+      const msg = parsed.error.errors
+        .map((e) => `${e.path.join(".")}: ${e.message}`)
+        .join("; ");
+      return {
+        content: [{ type: "text", text: `Invalid input: ${msg}` }],
+        isError: true,
+      };
+    }
+
+    const { sending_domain_id: sendingDomainId, ...params } = parsed.data;
+
+    const mailtrap = requireClient("sending domains");
+
+    const domain = await mailtrap.sendingDomains.update(
+      sendingDomainId,
+      params
+    );
+
+    return buildSuccessResponse(
+      [
+        `Sending domain ${domain.domain_name} (ID: ${domain.id}) updated.`,
+        `Open tracking: ${domain.open_tracking_enabled}`,
+        `Click tracking: ${domain.click_tracking_enabled}`,
+        `Tracking opt-out link: ${domain.tracking_opt_out_enabled}`,
+        `Auto unsubscribe link: ${domain.auto_unsubscribe_link_enabled}`,
+        `Inbound enabled: ${domain.inbound_enabled}`,
+      ].join("\n")
+    );
+  } catch (error) {
+    return buildErrorResponse("update sending domain", error);
+  }
+}
+
+export default updateSendingDomain;

--- a/src/tools/suppressions/__tests__/createSuppression.test.ts
+++ b/src/tools/suppressions/__tests__/createSuppression.test.ts
@@ -1,0 +1,119 @@
+import createSuppression from "../createSuppression";
+import { requireClient } from "../../../client";
+
+const mockClient = {
+  suppressions: {
+    create: jest.fn(),
+  },
+};
+
+jest.mock("../../../client", () => ({
+  requireClient: jest.fn(() => mockClient),
+}));
+
+const created = {
+  id: "abc-1",
+  email: "alice@example.com",
+  type: "manual import",
+  sending_stream: "transactional",
+  domain_name: "example.com",
+  created_at: "2026-05-19T10:00:00Z",
+};
+
+describe("createSuppression", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (requireClient as jest.Mock).mockReturnValue(mockClient);
+  });
+
+  it("creates the suppression and reports the result", async () => {
+    mockClient.suppressions.create.mockResolvedValue({ data: created });
+
+    const result = await createSuppression({
+      email: "alice@example.com",
+      domain_id: 4321,
+      sending_stream: "transactional",
+    });
+
+    expect(requireClient).toHaveBeenCalledWith("suppressions");
+    expect(mockClient.suppressions.create).toHaveBeenCalledWith({
+      email: "alice@example.com",
+      domain_id: 4321,
+      sending_stream: "transactional",
+    });
+    expect(result.content[0].text).toBe(
+      "Suppression created: alice@example.com (ID: abc-1, type: manual import, stream: transactional, domain: example.com)."
+    );
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("forwards type when provided", async () => {
+    mockClient.suppressions.create.mockResolvedValue({ data: created });
+
+    await createSuppression({
+      email: "alice@example.com",
+      domain_id: 4321,
+      sending_stream: "bulk",
+      type: "unsubscription",
+    });
+
+    expect(mockClient.suppressions.create).toHaveBeenCalledWith({
+      email: "alice@example.com",
+      domain_id: 4321,
+      sending_stream: "bulk",
+      type: "unsubscription",
+    });
+  });
+
+  it("rejects a sending stream the endpoint does not accept", async () => {
+    const result = await createSuppression({
+      email: "alice@example.com",
+      domain_id: 4321,
+      sending_stream: "any",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("sending_stream");
+    expect(mockClient.suppressions.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing domain id", async () => {
+    const result = await createSuppression({
+      email: "alice@example.com",
+      sending_stream: "transactional",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("domain_id");
+    expect(mockClient.suppressions.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects unknown properties", async () => {
+    const result = await createSuppression({
+      email: "alice@example.com",
+      domain_id: 4321,
+      sending_stream: "transactional",
+      reason: "typo for type",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(mockClient.suppressions.create).not.toHaveBeenCalled();
+  });
+
+  it("surfaces API errors", async () => {
+    mockClient.suppressions.create.mockRejectedValue(
+      new Error("domain not found")
+    );
+
+    const result = await createSuppression({
+      email: "alice@example.com",
+      domain_id: 4321,
+      sending_stream: "transactional",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe(
+      "Failed to create suppression: domain not found"
+    );
+  });
+});

--- a/src/tools/suppressions/createSuppression.ts
+++ b/src/tools/suppressions/createSuppression.ts
@@ -1,0 +1,36 @@
+import { requireClient } from "../../client";
+import {
+  buildErrorResponse,
+  buildSuccessResponse,
+  ToolResponse,
+} from "../utils/responses";
+import { createSuppressionZod } from "./schemas/createSuppression";
+
+async function createSuppression(raw: unknown): Promise<ToolResponse> {
+  try {
+    const parsed = createSuppressionZod.safeParse(raw ?? {});
+    if (!parsed.success) {
+      const msg = parsed.error.errors
+        .map((e) => `${e.path.join(".")}: ${e.message}`)
+        .join("; ");
+      return {
+        content: [{ type: "text", text: `Invalid input: ${msg}` }],
+        isError: true,
+      };
+    }
+
+    const mailtrap = requireClient("suppressions");
+
+    const response = await mailtrap.suppressions.create(parsed.data);
+
+    const created = response.data;
+
+    return buildSuccessResponse(
+      `Suppression created: ${created.email} (ID: ${created.id}, type: ${created.type}, stream: ${created.sending_stream}, domain: ${created.domain_name}).`
+    );
+  } catch (error) {
+    return buildErrorResponse("create suppression", error);
+  }
+}
+
+export default createSuppression;

--- a/src/tools/suppressions/index.ts
+++ b/src/tools/suppressions/index.ts
@@ -1,11 +1,15 @@
 import listSuppressionsSchema from "./schemas/listSuppressions";
 import listSuppressions from "./listSuppressions";
+import createSuppressionSchema from "./schemas/createSuppression";
+import createSuppression from "./createSuppression";
 import deleteSuppressionSchema from "./schemas/deleteSuppression";
 import deleteSuppression from "./deleteSuppression";
 
 export {
   listSuppressionsSchema,
   listSuppressions,
+  createSuppressionSchema,
+  createSuppression,
   deleteSuppressionSchema,
   deleteSuppression,
 };

--- a/src/tools/suppressions/schemas/createSuppression.ts
+++ b/src/tools/suppressions/schemas/createSuppression.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+
+const createSuppressionSchema = {
+  type: "object",
+  properties: {
+    email: {
+      type: "string",
+      description: "Email address to suppress.",
+    },
+    domain_id: {
+      type: "integer",
+      minimum: 1,
+      description:
+        "ID of the sending domain the suppression applies to, as returned by the Sending Domains tools.",
+    },
+    sending_stream: {
+      type: "string",
+      enum: ["transactional", "bulk"],
+      description: "Sending stream to suppress the address for.",
+    },
+    type: {
+      type: "string",
+      enum: [
+        "hard bounce",
+        "spam complaint",
+        "unsubscription",
+        "manual import",
+      ],
+      description:
+        "Reason recorded for the suppression. Defaults to `manual import` when omitted.",
+    },
+  },
+  required: ["email", "domain_id", "sending_stream"],
+  additionalProperties: false,
+};
+
+export const createSuppressionZod = z
+  .object({
+    email: z.string().min(1),
+    domain_id: z.number().int().min(1),
+    sending_stream: z.enum(["transactional", "bulk"]),
+    type: z
+      .enum([
+        "hard bounce",
+        "spam complaint",
+        "unsubscription",
+        "manual import",
+      ])
+      .optional(),
+  })
+  .strict();
+
+export default createSuppressionSchema;

--- a/src/tools/trackingOptOuts/__tests__/createTrackingOptOut.test.ts
+++ b/src/tools/trackingOptOuts/__tests__/createTrackingOptOut.test.ts
@@ -1,0 +1,95 @@
+import createTrackingOptOut from "../createTrackingOptOut";
+import { requireClient } from "../../../client";
+
+const mockClient = {
+  trackingOptOuts: {
+    create: jest.fn(),
+  },
+};
+
+jest.mock("../../../client", () => ({
+  requireClient: jest.fn(() => mockClient),
+}));
+
+describe("createTrackingOptOut", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (requireClient as jest.Mock).mockReturnValue(mockClient);
+  });
+
+  it("creates the tracking opt-out and reports the result", async () => {
+    mockClient.trackingOptOuts.create.mockResolvedValue({
+      data: {
+        id: "abc-1",
+        email: "alice@example.com",
+        domain_name: "example.com",
+        created_at: "2026-05-19T10:00:00Z",
+      },
+    });
+
+    const result = await createTrackingOptOut({
+      email: "alice@example.com",
+      domain_id: 4321,
+    });
+
+    expect(requireClient).toHaveBeenCalledWith("tracking opt-outs", {
+      requireAccountId: false,
+    });
+    expect(mockClient.trackingOptOuts.create).toHaveBeenCalledWith({
+      email: "alice@example.com",
+      domain_id: 4321,
+    });
+    expect(result.content[0].text).toBe(
+      "Tracking opt-out created: alice@example.com (ID: abc-1, domain: example.com, created: 2026-05-19T10:00:00Z)."
+    );
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("rejects a missing domain id", async () => {
+    const result = await createTrackingOptOut({
+      email: "alice@example.com",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("domain_id");
+    expect(mockClient.trackingOptOuts.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-positive domain id", async () => {
+    const result = await createTrackingOptOut({
+      email: "alice@example.com",
+      domain_id: 0,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("domain_id");
+    expect(mockClient.trackingOptOuts.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects unknown properties", async () => {
+    const result = await createTrackingOptOut({
+      email: "alice@example.com",
+      domain_id: 4321,
+      domain_name: "example.com",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(mockClient.trackingOptOuts.create).not.toHaveBeenCalled();
+  });
+
+  it("surfaces API errors", async () => {
+    mockClient.trackingOptOuts.create.mockRejectedValue(
+      new Error("domain not found")
+    );
+
+    const result = await createTrackingOptOut({
+      email: "alice@example.com",
+      domain_id: 4321,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe(
+      "Failed to create tracking opt-out: domain not found"
+    );
+  });
+});

--- a/src/tools/trackingOptOuts/__tests__/deleteTrackingOptOut.test.ts
+++ b/src/tools/trackingOptOuts/__tests__/deleteTrackingOptOut.test.ts
@@ -1,0 +1,54 @@
+import deleteTrackingOptOut from "../deleteTrackingOptOut";
+import { requireClient } from "../../../client";
+
+const mockClient = {
+  trackingOptOuts: {
+    delete: jest.fn(),
+  },
+};
+
+jest.mock("../../../client", () => ({
+  requireClient: jest.fn(() => mockClient),
+}));
+
+describe("deleteTrackingOptOut", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (requireClient as jest.Mock).mockReturnValue(mockClient);
+  });
+
+  it("deletes the tracking opt-out and reports the result", async () => {
+    mockClient.trackingOptOuts.delete.mockResolvedValue({
+      id: "abc-1",
+      email: "alice@example.com",
+      domain_name: "example.com",
+      created_at: "2026-05-19T10:00:00Z",
+    });
+
+    const result = await deleteTrackingOptOut({
+      tracking_opt_out_id: "abc-1",
+    });
+
+    expect(requireClient).toHaveBeenCalledWith("tracking opt-outs", {
+      requireAccountId: false,
+    });
+    expect(mockClient.trackingOptOuts.delete).toHaveBeenCalledWith("abc-1");
+    expect(result.content[0].text).toBe(
+      "Tracking opt-out abc-1 (alice@example.com) deleted. Open and click tracking applies to this address again."
+    );
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("surfaces API errors", async () => {
+    mockClient.trackingOptOuts.delete.mockRejectedValue(new Error("not found"));
+
+    const result = await deleteTrackingOptOut({
+      tracking_opt_out_id: "missing",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe(
+      "Failed to delete tracking opt-out: not found"
+    );
+  });
+});

--- a/src/tools/trackingOptOuts/__tests__/listTrackingOptOuts.test.ts
+++ b/src/tools/trackingOptOuts/__tests__/listTrackingOptOuts.test.ts
@@ -1,0 +1,105 @@
+import listTrackingOptOuts from "../listTrackingOptOuts";
+import { requireClient } from "../../../client";
+
+const mockClient = {
+  trackingOptOuts: {
+    getList: jest.fn(),
+  },
+};
+
+jest.mock("../../../client", () => ({
+  requireClient: jest.fn(() => mockClient),
+}));
+
+describe("listTrackingOptOuts", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (requireClient as jest.Mock).mockReturnValue(mockClient);
+  });
+
+  it("lists tracking opt-outs without filters", async () => {
+    mockClient.trackingOptOuts.getList.mockResolvedValue({
+      data: [
+        {
+          id: "abc-1",
+          email: "alice@example.com",
+          domain_name: "example.com",
+          created_at: "2026-05-19T10:00:00Z",
+        },
+      ],
+      last_id: null,
+    });
+
+    const result = await listTrackingOptOuts();
+
+    expect(requireClient).toHaveBeenCalledWith("tracking opt-outs", {
+      requireAccountId: false,
+    });
+    expect(mockClient.trackingOptOuts.getList).toHaveBeenCalledWith({});
+    expect(result.content[0].text).toContain("Tracking opt-outs (1):");
+    expect(result.content[0].text).toContain("alice@example.com");
+    expect(result.content[0].text).not.toContain("More results available");
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("forwards every filter and surfaces the pagination cursor", async () => {
+    mockClient.trackingOptOuts.getList.mockResolvedValue({
+      data: [{ id: "abc-2", email: "bob@example.com", domain_name: null }],
+      last_id: "abc-2",
+    });
+
+    const result = await listTrackingOptOuts({
+      email: "bob@example.com",
+      start_time: "2026-08-01T00:00:00Z",
+      end_time: "2026-08-31T23:59:59Z",
+      last_id: "abc-1",
+    });
+
+    expect(mockClient.trackingOptOuts.getList).toHaveBeenCalledWith({
+      email: "bob@example.com",
+      start_time: "2026-08-01T00:00:00Z",
+      end_time: "2026-08-31T23:59:59Z",
+      last_id: "abc-1",
+    });
+    expect(result.content[0].text).toContain('last_id: "abc-2"');
+  });
+
+  it("reports an empty list", async () => {
+    mockClient.trackingOptOuts.getList.mockResolvedValue({
+      data: [],
+      last_id: null,
+    });
+
+    const result = await listTrackingOptOuts();
+
+    expect(result.content[0].text).toBe(
+      "No tracking opt-outs in your Mailtrap account."
+    );
+  });
+
+  it("reports an empty filtered list", async () => {
+    mockClient.trackingOptOuts.getList.mockResolvedValue({
+      data: [],
+      last_id: null,
+    });
+
+    const result = await listTrackingOptOuts({ email: "nobody@example.com" });
+
+    expect(result.content[0].text).toBe(
+      'No tracking opt-outs found matching email "nobody@example.com".'
+    );
+  });
+
+  it("surfaces API errors", async () => {
+    mockClient.trackingOptOuts.getList.mockRejectedValue(
+      new Error("unauthorized")
+    );
+
+    const result = await listTrackingOptOuts();
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe(
+      "Failed to list tracking opt-outs: unauthorized"
+    );
+  });
+});

--- a/src/tools/trackingOptOuts/createTrackingOptOut.ts
+++ b/src/tools/trackingOptOuts/createTrackingOptOut.ts
@@ -1,0 +1,38 @@
+import { requireClient } from "../../client";
+import {
+  buildErrorResponse,
+  buildSuccessResponse,
+  ToolResponse,
+} from "../utils/responses";
+import { createTrackingOptOutZod } from "./schemas/createTrackingOptOut";
+
+async function createTrackingOptOut(raw: unknown): Promise<ToolResponse> {
+  try {
+    const parsed = createTrackingOptOutZod.safeParse(raw ?? {});
+    if (!parsed.success) {
+      const msg = parsed.error.errors
+        .map((e) => `${e.path.join(".")}: ${e.message}`)
+        .join("; ");
+      return {
+        content: [{ type: "text", text: `Invalid input: ${msg}` }],
+        isError: true,
+      };
+    }
+
+    const mailtrap = requireClient("tracking opt-outs", {
+      requireAccountId: false,
+    });
+
+    const response = await mailtrap.trackingOptOuts.create(parsed.data);
+
+    const created = response.data;
+
+    return buildSuccessResponse(
+      `Tracking opt-out created: ${created.email} (ID: ${created.id}, domain: ${created.domain_name}, created: ${created.created_at}).`
+    );
+  } catch (error) {
+    return buildErrorResponse("create tracking opt-out", error);
+  }
+}
+
+export default createTrackingOptOut;

--- a/src/tools/trackingOptOuts/deleteTrackingOptOut.ts
+++ b/src/tools/trackingOptOuts/deleteTrackingOptOut.ts
@@ -1,0 +1,27 @@
+import { requireClient } from "../../client";
+import { DeleteTrackingOptOutRequest } from "../../types/mailtrap";
+import {
+  buildErrorResponse,
+  buildSuccessResponse,
+  ToolResponse,
+} from "../utils/responses";
+
+async function deleteTrackingOptOut({
+  tracking_opt_out_id,
+}: DeleteTrackingOptOutRequest): Promise<ToolResponse> {
+  try {
+    const mailtrap = requireClient("tracking opt-outs", {
+      requireAccountId: false,
+    });
+
+    const deleted = await mailtrap.trackingOptOuts.delete(tracking_opt_out_id);
+
+    return buildSuccessResponse(
+      `Tracking opt-out ${deleted.id} (${deleted.email}) deleted. Open and click tracking applies to this address again.`
+    );
+  } catch (error) {
+    return buildErrorResponse("delete tracking opt-out", error);
+  }
+}
+
+export default deleteTrackingOptOut;

--- a/src/tools/trackingOptOuts/index.ts
+++ b/src/tools/trackingOptOuts/index.ts
@@ -1,4 +1,11 @@
 import listTrackingOptOutsSchema from "./schemas/listTrackingOptOuts";
 import listTrackingOptOuts from "./listTrackingOptOuts";
+import createTrackingOptOutSchema from "./schemas/createTrackingOptOut";
+import createTrackingOptOut from "./createTrackingOptOut";
 
-export { listTrackingOptOutsSchema, listTrackingOptOuts };
+export {
+  listTrackingOptOutsSchema,
+  listTrackingOptOuts,
+  createTrackingOptOutSchema,
+  createTrackingOptOut,
+};

--- a/src/tools/trackingOptOuts/index.ts
+++ b/src/tools/trackingOptOuts/index.ts
@@ -1,0 +1,4 @@
+import listTrackingOptOutsSchema from "./schemas/listTrackingOptOuts";
+import listTrackingOptOuts from "./listTrackingOptOuts";
+
+export { listTrackingOptOutsSchema, listTrackingOptOuts };

--- a/src/tools/trackingOptOuts/index.ts
+++ b/src/tools/trackingOptOuts/index.ts
@@ -2,10 +2,14 @@ import listTrackingOptOutsSchema from "./schemas/listTrackingOptOuts";
 import listTrackingOptOuts from "./listTrackingOptOuts";
 import createTrackingOptOutSchema from "./schemas/createTrackingOptOut";
 import createTrackingOptOut from "./createTrackingOptOut";
+import deleteTrackingOptOutSchema from "./schemas/deleteTrackingOptOut";
+import deleteTrackingOptOut from "./deleteTrackingOptOut";
 
 export {
   listTrackingOptOutsSchema,
   listTrackingOptOuts,
   createTrackingOptOutSchema,
   createTrackingOptOut,
+  deleteTrackingOptOutSchema,
+  deleteTrackingOptOut,
 };

--- a/src/tools/trackingOptOuts/listTrackingOptOuts.ts
+++ b/src/tools/trackingOptOuts/listTrackingOptOuts.ts
@@ -1,0 +1,54 @@
+import { requireClient } from "../../client";
+import { ListTrackingOptOutsRequest } from "../../types/mailtrap";
+import {
+  buildErrorResponse,
+  buildSuccessResponse,
+  ToolResponse,
+} from "../utils/responses";
+
+async function listTrackingOptOuts({
+  email,
+  start_time,
+  end_time,
+  last_id,
+}: ListTrackingOptOutsRequest = {}): Promise<ToolResponse> {
+  try {
+    const mailtrap = requireClient("tracking opt-outs", {
+      requireAccountId: false,
+    });
+
+    const response = await mailtrap.trackingOptOuts.getList({
+      ...(email !== undefined && { email }),
+      ...(start_time !== undefined && { start_time }),
+      ...(end_time !== undefined && { end_time }),
+      ...(last_id !== undefined && { last_id }),
+    });
+
+    const optOuts = response.data;
+
+    if (!optOuts || optOuts.length === 0) {
+      return buildSuccessResponse(
+        email
+          ? `No tracking opt-outs found matching email "${email}".`
+          : "No tracking opt-outs in your Mailtrap account."
+      );
+    }
+
+    const lines = optOuts.map(
+      (o) =>
+        `• ${o.email} (ID: ${o.id}, domain: ${o.domain_name}, created: ${o.created_at})`
+    );
+
+    const nextPage = response.last_id
+      ? `\n\nMore results available — pass last_id: "${response.last_id}" to fetch the next page.`
+      : "";
+
+    return buildSuccessResponse(
+      `Tracking opt-outs (${optOuts.length}):\n\n${lines.join("\n")}${nextPage}`
+    );
+  } catch (error) {
+    return buildErrorResponse("list tracking opt-outs", error);
+  }
+}
+
+export default listTrackingOptOuts;

--- a/src/tools/trackingOptOuts/schemas/createTrackingOptOut.ts
+++ b/src/tools/trackingOptOuts/schemas/createTrackingOptOut.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+const createTrackingOptOutSchema = {
+  type: "object",
+  properties: {
+    email: {
+      type: "string",
+      description: "Email address to opt out of open and click tracking.",
+    },
+    domain_id: {
+      type: "integer",
+      minimum: 1,
+      description:
+        "ID of the sending domain the opt-out applies to, as returned by the Sending Domains tools.",
+    },
+  },
+  required: ["email", "domain_id"],
+  additionalProperties: false,
+};
+
+export const createTrackingOptOutZod = z
+  .object({
+    email: z.string().min(1),
+    domain_id: z.number().int().min(1),
+  })
+  .strict();
+
+export default createTrackingOptOutSchema;

--- a/src/tools/trackingOptOuts/schemas/deleteTrackingOptOut.ts
+++ b/src/tools/trackingOptOuts/schemas/deleteTrackingOptOut.ts
@@ -1,0 +1,13 @@
+const deleteTrackingOptOutSchema = {
+  type: "object",
+  properties: {
+    tracking_opt_out_id: {
+      type: "string",
+      description: "ID of the tracking opt-out to delete",
+    },
+  },
+  required: ["tracking_opt_out_id"],
+  additionalProperties: false,
+};
+
+export default deleteTrackingOptOutSchema;

--- a/src/tools/trackingOptOuts/schemas/listTrackingOptOuts.ts
+++ b/src/tools/trackingOptOuts/schemas/listTrackingOptOuts.ts
@@ -1,0 +1,28 @@
+const listTrackingOptOutsSchema = {
+  type: "object",
+  properties: {
+    email: {
+      type: "string",
+      description:
+        "Optional email filter. Returns tracking opt-outs matching this address.",
+    },
+    start_time: {
+      type: "string",
+      description:
+        "Only opt-outs created at or after this time (ISO 8601, e.g. 2026-08-01T00:00:00Z).",
+    },
+    end_time: {
+      type: "string",
+      description:
+        "Only opt-outs created at or before this time (ISO 8601, e.g. 2026-08-31T23:59:59Z).",
+    },
+    last_id: {
+      type: "string",
+      description:
+        "Pagination cursor — the `last_id` from the previous response, to fetch the next page.",
+    },
+  },
+  additionalProperties: false,
+};
+
+export default listTrackingOptOutsSchema;

--- a/src/types/mailtrap.ts
+++ b/src/types/mailtrap.ts
@@ -907,3 +907,17 @@ export interface CompanyInfo {
 export interface GetCompanyInfoRequest {
   sending_domain_id: number;
 }
+
+export interface CreateCompanyInfoRequest {
+  sending_domain_id: number;
+  name: string;
+  address: string;
+  city: string;
+  country: string;
+  zip_code: string;
+  website_url: string;
+  phone?: string;
+  privacy_policy_url?: string;
+  terms_of_service_url?: string;
+  info_level?: CompanyInfoLevel;
+}

--- a/src/types/mailtrap.ts
+++ b/src/types/mailtrap.ts
@@ -921,3 +921,17 @@ export interface CreateCompanyInfoRequest {
   terms_of_service_url?: string;
   info_level?: CompanyInfoLevel;
 }
+
+export interface UpdateCompanyInfoRequest {
+  sending_domain_id: number;
+  name?: string;
+  address?: string;
+  city?: string;
+  country?: string;
+  zip_code?: string;
+  website_url?: string;
+  phone?: string;
+  privacy_policy_url?: string;
+  terms_of_service_url?: string;
+  info_level?: CompanyInfoLevel;
+}

--- a/src/types/mailtrap.ts
+++ b/src/types/mailtrap.ts
@@ -971,3 +971,7 @@ export interface CreateTrackingOptOutRequest {
   email: string;
   domain_id: number;
 }
+
+export interface DeleteTrackingOptOutRequest {
+  tracking_opt_out_id: string;
+}

--- a/src/types/mailtrap.ts
+++ b/src/types/mailtrap.ts
@@ -950,3 +950,19 @@ export interface UpdateCompanyInfoRequest {
   terms_of_service_url?: string;
   info_level?: CompanyInfoLevel;
 }
+
+// --- Tracking opt-out types ---
+
+export interface TrackingOptOut {
+  id: string;
+  email: string;
+  created_at: string;
+  domain_name: string | null;
+}
+
+export interface ListTrackingOptOutsRequest {
+  email?: string;
+  start_time?: string;
+  end_time?: string;
+  last_id?: string;
+}

--- a/src/types/mailtrap.ts
+++ b/src/types/mailtrap.ts
@@ -886,3 +886,24 @@ export interface UpdateSendingDomainParams {
 export interface UpdateSendingDomainRequest extends UpdateSendingDomainParams {
   sending_domain_id: number;
 }
+
+// --- Company info types ---
+
+export type CompanyInfoLevel = "business" | "individual";
+
+export interface CompanyInfo {
+  name: string | null;
+  address: string | null;
+  city: string | null;
+  country: string | null;
+  phone: string | null;
+  zip_code: string | null;
+  privacy_policy_url: string | null;
+  terms_of_service_url: string | null;
+  website_url: string | null;
+  info_level: CompanyInfoLevel;
+}
+
+export interface GetCompanyInfoRequest {
+  sending_domain_id: number;
+}

--- a/src/types/mailtrap.ts
+++ b/src/types/mailtrap.ts
@@ -872,3 +872,17 @@ export interface SubAccount {
 export interface CreateSubAccountRequest {
   name: string;
 }
+
+// --- Sending domain types ---
+
+export interface UpdateSendingDomainParams {
+  open_tracking_enabled?: boolean;
+  click_tracking_enabled?: boolean;
+  tracking_opt_out_enabled?: boolean;
+  auto_unsubscribe_link_enabled?: boolean;
+  inbound_enabled?: boolean;
+}
+
+export interface UpdateSendingDomainRequest extends UpdateSendingDomainParams {
+  sending_domain_id: number;
+}

--- a/src/types/mailtrap.ts
+++ b/src/types/mailtrap.ts
@@ -966,3 +966,8 @@ export interface ListTrackingOptOutsRequest {
   end_time?: string;
   last_id?: string;
 }
+
+export interface CreateTrackingOptOutRequest {
+  email: string;
+  domain_id: number;
+}

--- a/src/types/mailtrap.ts
+++ b/src/types/mailtrap.ts
@@ -369,6 +369,12 @@ export type SuppressionType =
 
 export type SuppressionStream = "transactional" | "bulk" | "any";
 
+/**
+ * Streams a suppression can be created for. `any`, which a stored suppression
+ * may report, is not accepted on create.
+ */
+export type CreateSuppressionStream = "transactional" | "bulk";
+
 export interface Suppression {
   id: string;
   type: SuppressionType;
@@ -380,6 +386,8 @@ export interface Suppression {
   message_category: string | null;
   message_client_ip: string | null;
   message_created_at: string | null;
+  message_esp_response: string | null;
+  message_esp_server_type: string | null;
   message_outgoing_ip: string | null;
   message_recipient_mx_name: string | null;
   message_sender_email: string | null;
@@ -388,6 +396,13 @@ export interface Suppression {
 
 export interface ListSuppressionsRequest {
   email?: string;
+}
+
+export interface CreateSuppressionRequest {
+  email: string;
+  domain_id: number;
+  sending_stream: CreateSuppressionStream;
+  type?: SuppressionType;
 }
 
 export interface DeleteSuppressionRequest {


### PR DESCRIPTION
Surfaces the endpoints added in mailtrap 4.10.0 as MCP tools: sending domain `PATCH`, company info (`GET`/`POST`/`PATCH`), create suppression, and the tracking opt-outs resource (`GET`/`POST`/`DELETE`). One commit per tool.

## Changes

- Bumps `mailtrap` to `^4.10.0`. The declared range was already `^4.9.0` but the installed tree was `4.8.0`, so type checking ran against the older types. 4.9.0 retyped `PermissionResourceParams.destroy` from `string` to `boolean`, which `bulkUpdatePermissions` was stringifying to satisfy the old signature — so `bulk-update-permissions` now sends `destroy` as a boolean rather than `"true"`.
- The same commit moves the `brace-expansion` override from `5.0.8` to `5.0.9`. It was pinned to the top of the range GHSA-rgw5-rvv9-x895 flags, so the pin itself was forcing the vulnerable version and `npm audit fix` could not resolve it. Clears 7 high advisories, all dev-only; `npm audit` now reports 0.
- **update-sending-domain** — the five settings the endpoint writes. The parameters keep the API's `_enabled` suffix so they match the fields the domain reads back.
- **get-company-info** / **create-company-info** / **update-company-info** — the nested `company_info` operations.
- **create-suppression** — `sending_stream` takes only `transactional` or `bulk`. A stored suppression may report `any`, but the endpoint does not accept it on create, so the create enum is narrower than the type used to read one back. `type` is left out unless passed, letting the API apply its own `manual import` default.
- **list-tracking-opt-outs** / **create-tracking-opt-out** / **delete-tracking-opt-out** — list takes `email`, `start_time`, `end_time` and `last_id`, and surfaces the returned cursor since a response is capped at 1000 records.
- Both update tools send only the fields passed and reject a call with none rather than an empty payload, following `update-email-campaign`. Company info and tracking opt-outs resolve the account from the API token, so they run without `MAILTRAP_ACCOUNT_ID`.
- Adds `message_esp_response` and `message_esp_server_type` to the `Suppression` type — the API returns both and the SDK exposes them.
- `manifest.json` lists every registered tool. The hand-maintained array had drifted to 31 of 125, so most of the server's capabilities were invisible to anyone browsing the extension. New descriptions are written for the listing rather than copied from the tool definitions, which name parameters and env vars; existing entries keep their wording.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tools to update sending-domain settings.
  * Added company information management for sending domains.
  * Added suppression creation and tracking opt-out creation, listing, and deletion.
  * Expanded the available tool catalog across email, sandbox, account, webhook, contact, campaign, token, and inbound-email operations.
* **Bug Fixes**
  * Preserved boolean permission values when updating permissions.
* **Documentation**
  * Clarified when account identification is optional and expanded usage examples and tool references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->