### PR TITLE
add delete-sub-account tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,5 +230,6 @@ Folders contain inboxes; inboxes receive messages, grouped into threads.
 
 - **list-sub-accounts**: List sub-accounts in the organization (requires `MAILTRAP_ORGANIZATION_ID`).
 - **create-sub-account**: Create a sub-account under the organization (requires `MAILTRAP_ORGANIZATION_ID`).
+- **delete-sub-account**: Permanently delete a sub-account by ID; deleting the last one deletes the organization (requires `MAILTRAP_ORGANIZATION_ID`).
 
 Tools use input schemas (JSON Schema format) for MCP; handlers may validate input with Zod. Response format follows the MCP protocol.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Before using this MCP server, you need to:
 - `DEFAULT_FROM_EMAIL` - Default sender email when `from` is not provided to send-email, send-sandbox-email, or the batch-send-\* tools (where it fills `base.from`). Enables switching sender per call via the `from` parameter.
 - `MAILTRAP_SANDBOX_ID` - Default sandbox ID for sandbox tools when `sandbox_id` is not provided. Enables switching between sandboxes per call via the `sandbox_id` parameter.
 - `MAILTRAP_TEST_INBOX_ID` - Default test inbox ID for sandbox tools when `test_inbox_id` is not provided. Enables switching between inboxes per call via the `test_inbox_id` parameter. Legacy alias for `MAILTRAP_SANDBOX_ID`, still honored as a fallback.
-- `MAILTRAP_ORGANIZATION_ID` - Required for organization tools (`list-sub-accounts`, `create-sub-account`).
+- `MAILTRAP_ORGANIZATION_ID` - Required for organization tools (`list-sub-accounts`, `create-sub-account`, `delete-sub-account`).
 - `MAILTRAP_ORGANIZATION_API_TOKEN` - Organization-scoped API token. Required for organization tools (separate from `MAILTRAP_API_TOKEN`).
 
 ## Quick Install
@@ -1183,6 +1183,14 @@ Create a new sub-account under the organization. Requires `MAILTRAP_ORGANIZATION
 **Parameters:**
 
 - `name` (required): Display name for the new sub-account
+
+### delete-sub-account
+
+Permanently delete a sub-account by ID, removing all of its data. Deleting the last sub-account deletes the organization; a repeated call returns 404. Requires `MAILTRAP_ORGANIZATION_ID` env var and sub-account management permissions.
+
+**Parameters:**
+
+- `sub_account_id` (required): ID of the sub-account to delete
 
 ### list-inbound-folders
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -248,6 +248,8 @@ import {
   listSubAccountsSchema,
   createSubAccount,
   createSubAccountSchema,
+  deleteSubAccount,
+  deleteSubAccountSchema,
 } from "./tools/organizations";
 import {
   listInboundFolders,
@@ -1311,6 +1313,16 @@ const tools = [
     handler: createSubAccount,
     annotations: {
       destructiveHint: false,
+    },
+  },
+  {
+    name: "delete-sub-account",
+    description:
+      "Permanently delete a sub-account by ID, removing all of its data. Deleting the last sub-account deletes the organization; a repeated call returns 404. Requires `MAILTRAP_ORGANIZATION_ID` and sub-account management permissions.",
+    inputSchema: deleteSubAccountSchema,
+    handler: deleteSubAccount,
+    annotations: {
+      destructiveHint: true,
     },
   },
   {

--- a/src/tools/organizations/__tests__/deleteSubAccount.test.ts
+++ b/src/tools/organizations/__tests__/deleteSubAccount.test.ts
@@ -1,0 +1,59 @@
+import deleteSubAccount from "../deleteSubAccount";
+import { getOrganizationClient } from "../../../client";
+
+const mockClient = {
+  organizations: {
+    subAccounts: {
+      delete: jest.fn(),
+    },
+  },
+};
+
+jest.mock("../../../client", () => ({
+  getOrganizationClient: jest.fn(() => mockClient),
+}));
+
+describe("deleteSubAccount", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getOrganizationClient as jest.Mock).mockReturnValue(mockClient);
+  });
+
+  it("deletes the sub-account via the organization client and confirms deletion", async () => {
+    mockClient.organizations.subAccounts.delete.mockResolvedValue(undefined);
+
+    const result = await deleteSubAccount({ sub_account_id: 99 });
+
+    expect(getOrganizationClient).toHaveBeenCalledWith();
+    expect(mockClient.organizations.subAccounts.delete).toHaveBeenCalledWith(
+      99
+    );
+    expect(result.content[0].text).toContain('"sub_account_id": 99');
+    expect(result.content[0].text).toContain('"deleted": true');
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("rejects invalid input before calling the SDK", async () => {
+    const result = await deleteSubAccount({ sub_account_id: "abc" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain(
+      "Failed to delete sub-account: Invalid input:"
+    );
+    expect(result.content[0].text).toContain("sub_account_id");
+    expect(mockClient.organizations.subAccounts.delete).not.toHaveBeenCalled();
+  });
+
+  it("surfaces API errors", async () => {
+    mockClient.organizations.subAccounts.delete.mockRejectedValue(
+      new Error("Not Found")
+    );
+
+    const result = await deleteSubAccount({ sub_account_id: 99 });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe(
+      "Failed to delete sub-account: Not Found"
+    );
+  });
+});

--- a/src/tools/organizations/deleteSubAccount.ts
+++ b/src/tools/organizations/deleteSubAccount.ts
@@ -1,0 +1,41 @@
+import { getOrganizationClient } from "../../client";
+import { deleteSubAccountZod } from "./schemas/deleteSubAccount";
+import {
+  buildErrorResponse,
+  buildSuccessResponse,
+  ToolResponse,
+} from "../utils/responses";
+
+async function deleteSubAccount(raw: unknown): Promise<ToolResponse> {
+  const parsed = deleteSubAccountZod.safeParse(raw);
+  if (!parsed.success) {
+    const msg = parsed.error.errors
+      .map((e) => `${e.path.join(".")}: ${e.message}`)
+      .join("; ");
+    return buildErrorResponse(
+      "delete sub-account",
+      new Error(`Invalid input: ${msg}`)
+    );
+  }
+
+  const subAccountId = parsed.data.sub_account_id;
+
+  try {
+    const mailtrap = getOrganizationClient();
+
+    // TODO: drop the cast after bumping mailtrap to the release that ships subAccounts.delete
+    const subAccounts = mailtrap.organizations.subAccounts as unknown as {
+      delete(id: number): Promise<void>;
+    };
+
+    await subAccounts.delete(subAccountId);
+
+    return buildSuccessResponse(
+      JSON.stringify({ sub_account_id: subAccountId, deleted: true }, null, 2)
+    );
+  } catch (error) {
+    return buildErrorResponse("delete sub-account", error);
+  }
+}
+
+export default deleteSubAccount;

--- a/src/tools/organizations/index.ts
+++ b/src/tools/organizations/index.ts
@@ -2,10 +2,14 @@ import listSubAccountsSchema from "./schemas/listSubAccounts";
 import listSubAccounts from "./listSubAccounts";
 import createSubAccountSchema from "./schemas/createSubAccount";
 import createSubAccount from "./createSubAccount";
+import deleteSubAccountSchema from "./schemas/deleteSubAccount";
+import deleteSubAccount from "./deleteSubAccount";
 
 export {
   listSubAccountsSchema,
   listSubAccounts,
   createSubAccountSchema,
   createSubAccount,
+  deleteSubAccountSchema,
+  deleteSubAccount,
 };

--- a/src/tools/organizations/schemas/deleteSubAccount.ts
+++ b/src/tools/organizations/schemas/deleteSubAccount.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+const deleteSubAccountSchema = {
+  type: "object",
+  properties: {
+    sub_account_id: {
+      type: "number",
+      description: "ID of the sub-account to delete.",
+    },
+  },
+  required: ["sub_account_id"],
+  additionalProperties: false,
+};
+
+export const deleteSubAccountZod = z
+  .object({
+    sub_account_id: z.number().int().positive(),
+  })
+  .strict();
+
+export default deleteSubAccountSchema;

--- a/src/types/mailtrap.ts
+++ b/src/types/mailtrap.ts
@@ -894,6 +894,10 @@ export interface CreateSubAccountRequest {
   name: string;
 }
 
+export interface DeleteSubAccountRequest {
+  sub_account_id: number;
+}
+
 // --- Sending domain types ---
 
 export interface UpdateSendingDomainParams {


### PR DESCRIPTION
## Motivation

The organization tools can list and create sub-accounts but not delete them. This adds a `delete-sub-account` tool for the new `DELETE /api/organizations/{organization_id}/sub_accounts/{sub_account_id}` endpoint.

## Changes

- new `delete-sub-account` tool (`sub_account_id` input, Zod-validated) that calls `organizations.subAccounts.delete` on the organization client and returns `{ sub_account_id, deleted: true }`
- marked `destructiveHint: true`; description notes the delete is permanent, the last sub-account deletion removes the organization, and a repeated call returns 404
- README and CLAUDE.md tool lists updated

## How to test

Run the server with `MAILTRAP_ORGANIZATION_ID` and `MAILTRAP_ORGANIZATION_API_TOKEN` set (e.g. `npm run build && npm run dev`).

- [ ] `list-sub-accounts` – note the id of a sub-account you can delete
- [ ] `delete-sub-account` with that `sub_account_id` → `{ "sub_account_id": <id>, "deleted": true }`, and `list-sub-accounts` no longer shows it
- [ ] `delete-sub-account` again with the same id → error containing 404 / not found
- [ ] `delete-sub-account` with an id from another organization, or with a token without sub-account management permissions → error containing 403
- [ ] `delete-sub-account` with an invalid `MAILTRAP_ORGANIZATION_API_TOKEN` → error containing 401
- [ ] `delete-sub-account` with `sub_account_id: "abc"` or `0` → `Failed to delete sub-account: Invalid input: ...`, no API call made
- [ ] delete the organization's only remaining sub-account → success, and `list-sub-accounts` afterwards fails because the organization is gone
- [ ] README `### delete-sub-account` section and the `MAILTRAP_ORGANIZATION_ID` line render correctly

## Companion PRs

- backend endpoint (must deploy first)
- mailtrap/mailtrap-openapi#56 – spec
- mailtrap/mailtrap-nodejs#159 – nodejs SDK
- mailtrap/mailtrap-ruby#130 – ruby SDK
- mailtrap/mailtrap-python#83 – python SDK
- mailtrap/mailtrap-php#80 – php SDK
- mailtrap/mailtrap-java#75 – java SDK
- mailtrap/mailtrap-dotnet#259 – .NET SDK
- mailtrap/mailtrap-go#30 – go SDK
- mailtrap/mailtrap-cli#15 – CLI

Caveat: merge and release only after the backend change ships; the endpoint is not in production yet.

Caveat: the released `mailtrap` package (4.10) has no `subAccounts.delete`, so the handler uses a narrow temporary cast. Before merging, bump `mailtrap` to the release that includes mailtrap/mailtrap-nodejs#159 and remove the cast.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `delete-sub-account` tool for permanently deleting a sub-account by ID.
  * Deleting the final sub-account also deletes its organization.
  * Added input validation and clear success or error responses.

* **Documentation**
  * Documented the new tool and its required organization configuration in the README and developer guidance.

* **Tests**
  * Added coverage for successful deletion, invalid IDs, and API errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->